### PR TITLE
Feature/set internal survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ Note: Make sure your .env file is properly configured with the correct database 
 
 The live version of the application can be accessed at these endpoints:
 
-- Main Survey: https://survey.csariel.xyz/?userID=...&surveyID=...
+- Main Survey: 
+  - Default survey (uses config survey ID): 
+    - https://survey.csariel.xyz/?userID=...&surveyID=...
+  - Custom survey ID: 
+    - https://survey.csariel.xyz/?userID=...&surveyID=...&internalID=2
 - Survey Report: https://survey.csariel.xyz/report
 - Development Report: https://survey.csariel.xyz/dev/report
 - Analytics Dashboard: https://survey.csariel.xyz/dashboard
@@ -144,7 +148,9 @@ Notes:
 
 - For the main survey endpoint, both 'userID' and 'surveyID' parameters are required in the URL.
 - The 'userID' parameter is used to obtain the user_id.
-- While the 'surveyID' parameter is required in the URL, it is not used by the application. Instead, the survey ID is hardcoded in the config file.
+- While the 'surveyID' parameter is required in the URL, it is not used by the application. Instead, the survey ID is determined by:
+  1. Custom internal survey ID if provided via `internalID` parameter at root endpoint
+  2. Falls back to the survey ID from config file if no custom ID is provided
 
 ## Endpoints
 

--- a/application/services/survey_service.py
+++ b/application/services/survey_service.py
@@ -37,16 +37,21 @@ class SurveyService:
             - data: Optional[Dict]: Survey data if exists, containing:
                 - name: str: Survey name
                 - subjects: List[str]: Survey subjects
+                - survey_id: int: The survey ID
         """
         survey_name = get_survey_name(survey_id)
         if not survey_name:
-            return False, "Survey not found", None
+            return False, ("survey_not_found", {"survey_id": survey_id}), None
 
         subjects = get_subjects(survey_id)
         if not subjects:
-            return False, "Survey has no subjects", None
+            return False, ("survey_not_found", {"survey_id": survey_id}), None
 
-        return True, None, {"name": survey_name, "subjects": subjects}
+        return (
+            True,
+            None,
+            {"name": survey_name, "subjects": subjects, "survey_id": survey_id},
+        )
 
     @staticmethod
     def check_user_eligibility(

--- a/application/translations.py
+++ b/application/translations.py
@@ -32,10 +32,13 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
             "he": "פרמטר חסר: {param}",
             "en": "Missing parameter: {param}",
         },
-        "survey_not_found": {"he": "הסקר לא נמצא", "en": "Survey not found"},
+        "survey_not_found": {
+            "he": "סקר מספר {survey_id} לא נמצא",
+            "en": "Survey #{survey_id} not found",
+        },
         "survey_no_subjects": {
-            "he": "הסקר לא נמצא או אין לו נושאים",
-            "en": "Survey not found or has no subjects",
+            "he": "סקר מספר {survey_id} לא נמצא או אין לו נושאים",
+            "en": "Survey #{survey_id} not found or has no subjects",
         },
         "report_error": {
             "he": "אירעה שגיאה בהפקת הדוח. אנא נסה שוב מאוחר יותר.",
@@ -60,6 +63,10 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
         "survey_retrieval_error": {
             "he": "אירעה שגיאה בעת אחזור נתוני הסקר. אנא נסו שוב מאוחר יותר.",
             "en": "An error occurred while retrieving the survey data. Please try again later.",
+        },
+        "invalid_parameter": {
+            "en": "Invalid parameter provided",
+            "he": "פרמטר לא חוקי",
         },
     },
     "survey": {  # Survey content


### PR DESCRIPTION
**PR: Feature/set internal survey**

Allow setting custom internal survey ID via URL parameter at root endpoint.

**Description:**  
Adds ability to specify custom internal survey ID using `internalID` parameter (e.g., `/?userID=123&surveyID=456&internalID=2`). The custom ID is stored in session and used throughout the survey flow. Enhances error messages to include survey ID for easier debugging.

**Key Changes:**
- Add URL parameter support for custom internal survey ID
- Store custom ID in session
- Improve error messages
- Update documentation