### PR TITLE
Feature/enhance strategy metrics

### DIFF
--- a/application/routes/survey_responses.py
+++ b/application/routes/survey_responses.py
@@ -70,10 +70,16 @@ def get_user_responses(
             if current_survey_id not in survey_labels:
                 strategy_config = get_survey_pair_generation_config(current_survey_id)
                 if strategy_config:
-                    strategy = StrategyRegistry.get_strategy(
-                        strategy_config["strategy"]
-                    )
-                    survey_labels[current_survey_id] = strategy.get_option_labels()
+                    try:
+                        strategy = StrategyRegistry.get_strategy(
+                            strategy_config["strategy"]
+                        )
+                        survey_labels[current_survey_id] = strategy.get_option_labels()
+                    except ValueError as e:
+                        logger.warning(
+                            f"Strategy not found for survey {current_survey_id}: {e}"
+                        )
+                        survey_labels[current_survey_id] = ("Option 1", "Option 2")
 
             # Add labels to choice
             if current_survey_id in survey_labels:

--- a/application/services/pair_generation/base.py
+++ b/application/services/pair_generation/base.py
@@ -143,22 +143,22 @@ class PairGenerationStrategy(ABC):
         Args:
             metric_type: Type of metric (e.g., 'sum', 'ratio', 'rss')
             best_value: The best value for this metric
-            worse_value: The worse value for this metric
+            worst_value: The worst value for this metric
 
         Returns:
             str: Description with both metric values
         """
         metric_type = kwargs.get("metric_type")
         best_value = kwargs.get("best_value")
-        worse_value = kwargs.get("worse_value")
+        worst_value = kwargs.get("worst_value")
 
-        if any(val is None for val in [metric_type, best_value, worse_value]):
+        if any(val is None for val in [metric_type, best_value, worst_value]):
             import json
 
             logger.warning("Kwargs received: %s", json.dumps(kwargs, indent=2))
             return "Unknown Vector"
 
-        return f"{self._get_metric_name(metric_type)}: {{best: {best_value:.2f}, worse: {worse_value:.2f}}}"
+        return f"{self._get_metric_name(metric_type)}: {{best: {best_value:.2f}, worst: {worst_value:.2f}}}"
 
     @abstractmethod
     def _get_metric_name(self, metric_type: str) -> str:

--- a/application/services/pair_generation/base.py
+++ b/application/services/pair_generation/base.py
@@ -136,17 +136,33 @@ class PairGenerationStrategy(ABC):
         """Return labels for the two options being compared."""
         pass
 
-    @abstractmethod
     def get_option_description(self, **kwargs) -> str:
         """
-        Get descriptive name for an option including parameters.
+        Get descriptive name for an option including all metric values.
 
         Args:
-            **kwargs: Strategy-specific parameters (e.g., weight, metrics)
+            metric_type: Type of metric (e.g., 'sum', 'ratio', 'rss')
+            best_value: The best value for this metric
+            worse_value: The worse value for this metric
 
         Returns:
-            str: Human-readable description with parameters
+            str: Description with both metric values
         """
+        metric_type = kwargs.get("metric_type")
+        best_value = kwargs.get("best_value")
+        worse_value = kwargs.get("worse_value")
+
+        if any(val is None for val in [metric_type, best_value, worse_value]):
+            import json
+
+            logger.warning("Kwargs received: %s", json.dumps(kwargs, indent=2))
+            return "Unknown Vector"
+
+        return f"{self._get_metric_name(metric_type)}: {{best: {best_value:.2f}, worse: {worse_value:.2f}}}"
+
+    @abstractmethod
+    def _get_metric_name(self, metric_type: str) -> str:
+        """Get the display name for a metric type."""
         pass
 
 

--- a/application/services/pair_generation/base.py
+++ b/application/services/pair_generation/base.py
@@ -150,15 +150,15 @@ class PairGenerationStrategy(ABC):
         """
         metric_type = kwargs.get("metric_type")
         best_value = kwargs.get("best_value")
-        worst_value = kwargs.get("worst_value")
+        worse_value = kwargs.get("worse_value")
 
-        if any(val is None for val in [metric_type, best_value, worst_value]):
+        if any(val is None for val in [metric_type, best_value, worse_value]):
             import json
 
             logger.warning("Kwargs received: %s", json.dumps(kwargs, indent=2))
             return "Unknown Vector"
 
-        return f"{self._get_metric_name(metric_type)}: {{best: {best_value:.2f}, worst: {worst_value:.2f}}}"
+        return f"{self._get_metric_name(metric_type)}: {{best: {best_value:.2f}, worst: {worse_value:.2f}}}"
 
     @abstractmethod
     def _get_metric_name(self, metric_type: str) -> str:

--- a/application/services/pair_generation/base.py
+++ b/application/services/pair_generation/base.py
@@ -150,15 +150,15 @@ class PairGenerationStrategy(ABC):
         """
         metric_type = kwargs.get("metric_type")
         best_value = kwargs.get("best_value")
-        worse_value = kwargs.get("worse_value")
+        worst_value = kwargs.get("worst_value")
 
-        if any(val is None for val in [metric_type, best_value, worse_value]):
+        if any(val is None for val in [metric_type, best_value, worst_value]):
             import json
 
             logger.warning("Kwargs received: %s", json.dumps(kwargs, indent=2))
             return "Unknown Vector"
 
-        return f"{self._get_metric_name(metric_type)}: {{best: {best_value:.2f}, worst: {worse_value:.2f}}}"
+        return f"{self._get_metric_name(metric_type)}: {{best: {best_value:.2f}, worst: {worst_value:.2f}}}"
 
     @abstractmethod
     def _get_metric_name(self, metric_type: str) -> str:

--- a/application/services/pair_generation/optimization_metrics_vector.py
+++ b/application/services/pair_generation/optimization_metrics_vector.py
@@ -213,13 +213,21 @@ class OptimizationMetricsStrategy(PairGenerationStrategy):
 
         if m1_1 < m1_2:  # v1 is better in first metric
             return {
-                self.get_option_description(metric_type=metric_type1, value=m1_1): v1,
-                self.get_option_description(metric_type=metric_type2, value=m2_2): v2,
+                self.get_option_description(
+                    metric_type=metric_type1, best_value=m1_1, worse_value=m1_2
+                ): v1,
+                self.get_option_description(
+                    metric_type=metric_type2, best_value=m2_2, worse_value=m2_1
+                ): v2,
             }
         else:  # v2 is better in first metric
             return {
-                self.get_option_description(metric_type=metric_type1, value=m1_2): v2,
-                self.get_option_description(metric_type=metric_type2, value=m2_1): v1,
+                self.get_option_description(
+                    metric_type=metric_type1, best_value=m1_2, worse_value=m1_1
+                ): v2,
+                self.get_option_description(
+                    metric_type=metric_type2, best_value=m2_1, worse_value=m2_2
+                ): v1,
             }
 
     def get_metric_types(self) -> tuple[str, str]:
@@ -234,12 +242,9 @@ class OptimizationMetricsStrategy(PairGenerationStrategy):
         """Get the unique labels for this strategy's options."""
         return ("Sum Optimized Vector", "Ratio Optimized Vector")
 
-    def get_option_description(self, **kwargs) -> str:
-        metric_type = kwargs.get("metric_type")
-        value = kwargs.get("value")
-
+    def _get_metric_name(self, metric_type: str) -> str:
         if metric_type == "sum":
-            return f"Sum Optimized Vector: {int(value)}"
+            return "Sum Optimized Vector"
         elif metric_type == "ratio":
-            return f"Ratio Optimized Vector: {value:.2f}"
+            return "Ratio Optimized Vector"
         return "Unknown Vector"

--- a/application/services/pair_generation/optimization_metrics_vector.py
+++ b/application/services/pair_generation/optimization_metrics_vector.py
@@ -214,19 +214,19 @@ class OptimizationMetricsStrategy(PairGenerationStrategy):
         if m1_1 < m1_2:  # v1 is better in first metric
             return {
                 self.get_option_description(
-                    metric_type=metric_type1, best_value=m1_1, worse_value=m1_2
+                    metric_type=metric_type1, best_value=m1_1, worst_value=m1_2
                 ): v1,
                 self.get_option_description(
-                    metric_type=metric_type2, best_value=m2_2, worse_value=m2_1
+                    metric_type=metric_type2, best_value=m2_2, worst_value=m2_1
                 ): v2,
             }
         else:  # v2 is better in first metric
             return {
                 self.get_option_description(
-                    metric_type=metric_type1, best_value=m1_2, worse_value=m1_1
+                    metric_type=metric_type1, best_value=m1_2, worst_value=m1_1
                 ): v2,
                 self.get_option_description(
-                    metric_type=metric_type2, best_value=m2_1, worse_value=m2_2
+                    metric_type=metric_type2, best_value=m2_1, worst_value=m2_2
                 ): v1,
             }
 

--- a/application/services/pair_generation/root_sum_squared_ratio_vector.py
+++ b/application/services/pair_generation/root_sum_squared_ratio_vector.py
@@ -96,13 +96,9 @@ class RootSumSquaredRatioStrategy(OptimizationMetricsStrategy):
         """Get the labels for the two types of optimization."""
         return ("Root Sum Squared Optimized Vector", "Ratio Optimized Vector")
 
-    def get_option_description(self, **kwargs) -> str:
-        """Get descriptive name for an option including the metric value."""
-        metric_type = kwargs.get("metric_type")
-        value = kwargs.get("value")
-
+    def _get_metric_name(self, metric_type: str) -> str:
         if metric_type == "rss":
-            return f"Root Sum Squared Optimized Vector: {value:.2f}"
+            return "Root Sum Squared Optimized Vector"
         elif metric_type == "ratio":
-            return f"Ratio Optimized Vector: {value:.2f}"
+            return "Ratio Optimized Vector"
         return "Unknown Vector"

--- a/application/services/pair_generation/root_sum_squared_sum_vector.py
+++ b/application/services/pair_generation/root_sum_squared_sum_vector.py
@@ -98,13 +98,9 @@ class RootSumSquaredSumStrategy(OptimizationMetricsStrategy):
         """Get the labels for the two types of optimization."""
         return ("Root Sum Squared Optimized Vector", "Sum Optimized Vector")
 
-    def get_option_description(self, **kwargs) -> str:
-        """Get descriptive name for an option including the metric value."""
-        metric_type = kwargs.get("metric_type")
-        value = kwargs.get("value")
-
+    def _get_metric_name(self, metric_type: str) -> str:
         if metric_type == "rss":
-            return f"Root Sum Squared Optimized Vector: {value:.2f}"
+            return "Root Sum Squared Optimized Vector"
         elif metric_type == "sum":
-            return f"Sum Optimized Vector: {int(value)}"
+            return "Sum Optimized Vector"
         return "Unknown Vector"

--- a/application/services/pair_generation/rounded_weighted_average_vector.py
+++ b/application/services/pair_generation/rounded_weighted_average_vector.py
@@ -88,16 +88,13 @@ class RoundedWeightedAverageVectorStrategy(WeightedAverageVectorStrategy):
     def get_option_labels(self) -> Tuple[str, str]:
         return ("Random Vector", "Rounded Weighted Average Vector")
 
+    def _get_metric_name(self, metric_type: str) -> str:
+        if metric_type == "weight":
+            return "Rounded Weighted Average Vector"
+        return "Random Vector"
+
     def get_option_description(self, **kwargs) -> str:
-        """
-        Get descriptive name for an option including weight parameter if applicable.
-
-        Args:
-            weight: Optional weight parameter for weighted vectors
-
-        Returns:
-            str: Description like "Rounded Weighted Vector: 70%"
-        """
+        """Override for rounded weight-based description."""
         weight = kwargs.get("weight")
         if weight is None:
             return "Random Vector"

--- a/application/services/pair_generation/weighted_average_vector.py
+++ b/application/services/pair_generation/weighted_average_vector.py
@@ -193,18 +193,14 @@ class WeightedAverageVectorStrategy(PairGenerationStrategy):
     def get_option_labels(self) -> Tuple[str, str]:
         return ("Random Vector", "Weighted Average Vector")
 
+    def _get_metric_name(self, metric_type: str) -> str:
+        if metric_type == "weight":
+            return "Average Weighted Vector"
+        return "Random Vector"
+
     def get_option_description(self, **kwargs) -> str:
-        """
-        Get descriptive name for an option including weight parameter if applicable.
-
-        Args:
-            weight: Optional weight parameter for weighted vectors
-
-        Returns:
-            str: Description like "Average Weighted Vector: 70%"
-        """
+        """Override for weight-based description."""
         weight = kwargs.get("weight")
-        logger.debug(f"get_option_description - weight: {weight}")
         if weight is None:
             return "Random Vector"
         return f"Average Weighted Vector: {int(weight * 100)}%"

--- a/application/static/css/responses_style.css
+++ b/application/static/css/responses_style.css
@@ -275,6 +275,7 @@
 .option-column {
    font-family: var(--font-family-mono);
    letter-spacing: -0.5px;
+   white-space: nowrap;
 }
 
 .table-container tr:hover {

--- a/application/static/css/responses_style.css
+++ b/application/static/css/responses_style.css
@@ -276,7 +276,7 @@
    font-family: var(--font-family-mono);
    letter-spacing: -0.5px;
    white-space: nowrap;
-}
+}clear
 
 .table-container tr:hover {
    background-color: var(--color-background-alt);

--- a/tests/services/pair_generation/test_base.py
+++ b/tests/services/pair_generation/test_base.py
@@ -28,6 +28,10 @@ class TestStrategy(PairGenerationStrategy):
         type_str = kwargs.get("type", "default")
         return f"Test {type_str.capitalize()} Vector"
 
+    def _get_metric_name(self, metric_type: str) -> str:
+        """Get the display name for a metric type."""
+        return f"Test {metric_type.capitalize()} Vector"
+
 
 @pytest.fixture
 def strategy():

--- a/tests/services/pair_generation/test_optimization_metrics_vector.py
+++ b/tests/services/pair_generation/test_optimization_metrics_vector.py
@@ -67,8 +67,8 @@ def test_generated_pairs_are_valid(strategy):
         sum_desc = next(desc for desc in descriptions if "Sum Optimized" in desc)
         ratio_desc = next(desc for desc in descriptions if "Ratio Optimized" in desc)
 
-        sum_value = float(sum_desc.split(": ")[1])
-        ratio_value = float(ratio_desc.split(": ")[1])
+        sum_value = float(sum_desc.split("best: ")[1].split(",")[0])
+        ratio_value = float(ratio_desc.split("best: ")[1].split(",")[0])
 
         # Verify that descriptions match actual metrics
         if sum_desc == descriptions[0]:  # First vector is sum-optimized
@@ -81,15 +81,20 @@ def test_generated_pairs_are_valid(strategy):
 
 def test_option_descriptions(strategy):
     """Test if option descriptions are generated correctly."""
-    description_sum = strategy.get_option_description(metric_type="sum", value=25)
-    description_ratio = strategy.get_option_description(metric_type="ratio", value=0.75)
+    description_sum = strategy.get_option_description(
+        metric_type="sum", best_value=25, worst_value=35
+    )
+    description_ratio = strategy.get_option_description(
+        metric_type="ratio", best_value=0.75, worst_value=0.60
+    )
 
-    assert description_sum == "Sum Optimized Vector: 25"
-    assert description_ratio == "Ratio Optimized Vector: 0.75"
-    assert strategy.get_strategy_name() == "optimization_metrics"
+    assert "Sum Optimized Vector" in description_sum
+    assert "best: 25.00" in description_sum
+    assert "worst: 35.00" in description_sum
 
-    labels = strategy.get_option_labels()
-    assert labels == ("Sum Optimized Vector", "Ratio Optimized Vector")
+    assert "Ratio Optimized Vector" in description_ratio
+    assert "best: 0.75" in description_ratio
+    assert "worst: 0.60" in description_ratio
 
 
 def test_generate_pairs_error_handling(strategy):
@@ -129,14 +134,13 @@ def test_metric_value_extraction(strategy):
     pairs = strategy.generate_pairs(user_vector, n=1, vector_size=3)
     pair = pairs[0]
 
-    # Extract values from descriptions
     descriptions = list(pair.keys())
     sum_desc = next(desc for desc in descriptions if "Sum Optimized" in desc)
     ratio_desc = next(desc for desc in descriptions if "Ratio Optimized" in desc)
 
-    # Verify format and value ranges
-    sum_value = float(sum_desc.split(": ")[1])
-    ratio_value = float(ratio_desc.split(": ")[1])
+    # Extract best values from the new format
+    sum_value = float(sum_desc.split("best: ")[1].split(",")[0])
+    ratio_value = float(ratio_desc.split("best: ")[1].split(",")[0])
 
     assert sum_value > 0, "Sum difference should be positive"
     assert 0 < ratio_value <= 1, "Ratio should be between 0 and 1"

--- a/tests/services/pair_generation/test_root_sum_squared_ratio_vector.py
+++ b/tests/services/pair_generation/test_root_sum_squared_ratio_vector.py
@@ -91,12 +91,25 @@ def test_generate_pairs(strategy):
 
 def test_option_descriptions(strategy):
     """Test if option descriptions are generated correctly."""
-    desc_rss = strategy.get_option_description(metric_type="rss", value=15.5)
-    desc_ratio = strategy.get_option_description(metric_type="ratio", value=0.75)
+    # Updated to include both best and worst values
+    desc_rss = strategy.get_option_description(
+        metric_type="rss", best_value=15.5, worst_value=20.0
+    )
+    desc_ratio = strategy.get_option_description(
+        metric_type="ratio", best_value=0.75, worst_value=0.60
+    )
 
-    assert desc_rss == "Root Sum Squared Optimized Vector: 15.50"
-    assert desc_ratio == "Ratio Optimized Vector: 0.75"
+    # Root Sum Squared vector checks
+    assert "Root Sum Squared Optimized Vector" in desc_rss
+    assert "best: 15.50" in desc_rss
+    assert "worst: 20.00" in desc_rss
 
+    # Ratio vector checks
+    assert "Ratio Optimized Vector" in desc_ratio
+    assert "best: 0.75" in desc_ratio
+    assert "worst: 0.60" in desc_ratio
+
+    # Label checks
     labels = strategy.get_option_labels()
     assert labels == ("Root Sum Squared Optimized Vector", "Ratio Optimized Vector")
 

--- a/tests/services/pair_generation/test_root_sum_squared_sum_vector.py
+++ b/tests/services/pair_generation/test_root_sum_squared_sum_vector.py
@@ -84,12 +84,24 @@ def test_generate_pairs(strategy):
 
 def test_option_descriptions(strategy):
     """Test if option descriptions are generated correctly."""
-    desc_rss = strategy.get_option_description(metric_type="rss", value=15.5)
-    desc_sum = strategy.get_option_description(metric_type="sum", value=25)
+    desc_rss = strategy.get_option_description(
+        metric_type="rss", best_value=15.5, worst_value=20.0
+    )
+    desc_sum = strategy.get_option_description(
+        metric_type="sum", best_value=25.0, worst_value=35.0
+    )
 
-    assert desc_rss == "Root Sum Squared Optimized Vector: 15.50"
-    assert desc_sum == "Sum Optimized Vector: 25"
+    # Root Sum Squared vector checks
+    assert "Root Sum Squared Optimized Vector" in desc_rss
+    assert "best: 15.50" in desc_rss
+    assert "worst: 20.00" in desc_rss
 
+    # Sum vector checks
+    assert "Sum Optimized Vector" in desc_sum
+    assert "best: 25.00" in desc_sum
+    assert "worst: 35.00" in desc_sum
+
+    # Label checks
     labels = strategy.get_option_labels()
     assert labels == ("Root Sum Squared Optimized Vector", "Sum Optimized Vector")
 


### PR DESCRIPTION
# Enhanced Strategy Metrics Display

Improves the display of optimization metrics in survey responses by:

1. Adding both best and worst values to strategy descriptions
2. Fixing vector display formatting in response tables

Before this PR, we only showed the best metric value for each strategy. Now, we provide both best and worst values to give a complete picture of the optimization choices, while maintaining the same database schema and backward compatibility.

## Example
Old format: `Root Sum Squared Optimized Vector: 55.23`
New format: `Root Sum Squared Optimized Vector: {best: 55.23, worst: 62.12}`

---
*No database changes required. All changes are backward compatible.*