### PR TITLE
Feature/user survey matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,8 +577,22 @@ The application provides a comprehensive dashboard showing participation statist
   - Sortable by User ID or Last Activity
   - Accessible via dashboard metric card or direct URL: `/surveys/users`
   - Full bilingual support with RTL/LTR layouts
+  - Navigation to Performance Matrix for detailed metrics
 
 - **Data Displayed**: User IDs, survey counts, last activity timestamps, and direct links to individual responses
+
+### User-Survey Performance Matrix
+The application provides a detailed matrix view showing strategy-specific performance metrics for each user-survey combination.
+
+- **Purpose**: Analyze user performance patterns across different survey strategies
+- **Key Features**:
+  - Matrix format with users as rows and surveys as columns
+  - Strategy-specific metric labels (e.g., "Random / Weighted Average", "Sum / Ratio")
+  - Sticky User ID column for easy navigation
+  - Full bilingual support with RTL/LTR layouts
+  - Accessible via direct URL: `/surveys/users/matrix`
+
+- **Data Displayed**: Performance metrics for each user-survey combination, with "-" indicating no participation
 
 ## Database
 
@@ -800,6 +814,9 @@ curl http://localhost:5001/health
      * Sortable by User ID or Last Activity
      * Shows successful/failed survey counts per user
      * Color-coded clickable survey IDs
+   - `/surveys/users/matrix` - User-Survey Performance Matrix
+     * Shows strategy-specific metrics for each user-survey combination
+     * Displays performance data across all surveys in a matrix format
    - `/surveys/users/{user_id}/responses` - All responses from specific user
    - `/surveys/{survey_id}/users/{user_id}/responses` - User's response to specific survey
    - `/surveys/comments` - All user comments
@@ -838,6 +855,9 @@ Notes:
      * Sortable by User ID or Last Activity
      * Shows successful/failed survey counts per user
      * Color-coded clickable survey IDs
+   - User-Survey Performance Matrix: https://survey.csariel.xyz/surveys/users/matrix
+     * Shows strategy-specific metrics for each user-survey combination
+     * Displays performance data across all surveys in a matrix format
    - User Responses: https://survey.csariel.xyz/surveys/users/{user_id}/responses
    - User Survey Response: https://survey.csariel.xyz/surveys/{survey_id}/users/{user_id}/responses
    - All Comments: https://survey.csariel.xyz/surveys/comments

--- a/analysis/report_content_generators.py
+++ b/analysis/report_content_generators.py
@@ -2462,47 +2462,57 @@ def generate_user_survey_matrix_html(performance_data: List[Dict]) -> str:
 
     # Get translations
     user_id_label = get_translation("user_id", "answers")
-    matrix_title = "User-Survey Performance Matrix"  # Fallback title
+    matrix_title = get_translation("user_survey_matrix", "answers")
+    matrix_description = get_translation("matrix_description", "answers")
+    users_summary_label = get_translation("matrix_summary_users", "answers")
+    surveys_summary_label = get_translation("matrix_summary_surveys", "answers")
+    responses_summary_label = get_translation(
+        "matrix_summary_total_responses", "answers"
+    )
+    survey_label = get_translation("survey_label", "answers")
 
     # Generate table headers
     header_cells = [f'<th class="matrix-user-header">{user_id_label}</th>']
 
     for survey_id in sorted_surveys:
         info = survey_info[survey_id]
-        # strategy_name = info["strategy_name"]
         strategy_columns = info["strategy_columns"]
 
-        # Generate column headers based on strategy
+        # Build the sub-header label using translations
+        sub_header = ""
         if "consistency" in strategy_columns:
-            header_cells.append(
-                f'<th class="matrix-survey-header" data-survey="{survey_id}">Survey {survey_id}<br><small>Consistency</small></th>'
-            )
+            sub_header = get_translation("consistency", "answers")
         elif (
             "group_consistency" in strategy_columns
             or "linear_consistency" in strategy_columns
         ):
-            header_cells.append(
-                f'<th class="matrix-survey-header" data-survey="{survey_id}">Survey {survey_id}<br><small>Group Consistency</small></th>'
-            )
+            sub_header = get_translation("group_consistency", "answers")
         elif "sum" in strategy_columns and "ratio" in strategy_columns:
-            header_cells.append(
-                f'<th class="matrix-survey-header" data-survey="{survey_id}">Survey {survey_id}<br><small>Sum / Ratio</small></th>'
-            )
+            sum_label = get_translation("sum", "answers")
+            ratio_label = get_translation("ratio", "answers")
+            sub_header = f"{sum_label} / {ratio_label}"
         elif "rss" in strategy_columns:
+            rss_label = get_translation("root_sum_squared", "answers")
             if "sum" in strategy_columns:
-                header_cells.append(
-                    f'<th class="matrix-survey-header" data-survey="{survey_id}">Survey {survey_id}<br><small>RSS / Sum</small></th>'
-                )
+                sum_label = get_translation("sum", "answers")
+                sub_header = f"{rss_label} / {sum_label}"
             elif "ratio" in strategy_columns:
-                header_cells.append(
-                    f'<th class="matrix-survey-header" data-survey="{survey_id}">Survey {survey_id}<br><small>RSS / Ratio</small></th>'
-                )
+                ratio_label = get_translation("ratio", "answers")
+                sub_header = f"{rss_label} / {ratio_label}"
+        elif "option1" in strategy_columns and "option2" in strategy_columns:
+            # This case correctly pulls from strategy definitions which should be translated
+            option1_name = strategy_columns["option1"]["name"]
+            option2_name = strategy_columns["option2"]["name"]
+            sub_header = f"{option1_name} / {option2_name}"
         else:
-            header_cells.append(
-                f'<th class="matrix-survey-header" data-survey="{survey_id}">Survey {survey_id}<br><small>Opt1 / Opt2</small></th>'
-            )
+            # Fallback for any other case
+            sub_header = "Opt1 / Opt2"
 
-    # Generate table rows
+        header_cells.append(
+            f'<th class="matrix-survey-header" data-survey="{survey_id}">{survey_label}: {survey_id}<br><small>{sub_header}</small></th>'
+        )
+
+    # Generate table rows (this part of the function remains the same)
     rows = []
     for user_id in sorted_users:
         user_data = users[user_id]
@@ -2534,7 +2544,6 @@ def generate_user_survey_matrix_html(performance_data: List[Dict]) -> str:
                 # Generate cell content based on strategy
                 if "consistency" in strategy_columns:
                     consistency = metrics.get("consistency", 0)
-                    highlight = "highlight-cell" if consistency >= 70 else ""
                     cell_content = f'<span class="metric-value">{consistency}%</span>'
 
                 elif (
@@ -2542,7 +2551,6 @@ def generate_user_survey_matrix_html(performance_data: List[Dict]) -> str:
                     or "linear_consistency" in strategy_columns
                 ):
                     consistency = metrics.get("group_consistency", 0.0)
-                    highlight = "highlight-cell" if consistency >= 80 else ""
                     cell_content = (
                         f'<span class="metric-value">{consistency:.0f}%</span>'
                     )
@@ -2550,37 +2558,34 @@ def generate_user_survey_matrix_html(performance_data: List[Dict]) -> str:
                 elif "sum" in strategy_columns and "ratio" in strategy_columns:
                     sum_percent = metrics.get("sum_percent", 0)
                     ratio_percent = metrics.get("ratio_percent", 0)
-                    highlight = "highlight-cell" if sum_percent > ratio_percent else ""
                     cell_content = f'<span class="metric-pair">{sum_percent:.0f}% / {ratio_percent:.0f}%</span>'
 
                 elif "rss" in strategy_columns:
                     rss_percent = metrics.get("rss_percent", 0)
                     if "sum" in strategy_columns:
                         sum_percent = metrics.get("sum_percent", 0)
-                        highlight = (
-                            "highlight-cell" if rss_percent > sum_percent else ""
-                        )
                         cell_content = f'<span class="metric-pair">{rss_percent:.0f}% / {sum_percent:.0f}%</span>'
                     elif "ratio" in strategy_columns:
                         ratio_percent = metrics.get("ratio_percent", 0)
-                        highlight = (
-                            "highlight-cell" if rss_percent > ratio_percent else ""
-                        )
                         cell_content = f'<span class="metric-pair">{rss_percent:.0f}% / {ratio_percent:.0f}%</span>'
                     else:
                         cell_content = (
                             f'<span class="metric-value">{rss_percent:.0f}%</span>'
                         )
-                        highlight = ""
+
+                elif "option1" in strategy_columns and "option2" in strategy_columns:
+                    # Generic case for strategies with option1/option2 columns
+                    opt1_percent = metrics.get("option1_percent", 0)
+                    opt2_percent = metrics.get("option2_percent", 0)
+                    cell_content = f'<span class="metric-pair">{opt1_percent:.0f}% / {opt2_percent:.0f}%</span>'
 
                 else:
                     opt1_percent = metrics.get("option1_percent", 0)
                     opt2_percent = metrics.get("option2_percent", 0)
-                    highlight = "highlight-cell" if opt1_percent > opt2_percent else ""
                     cell_content = f'<span class="metric-pair">{opt1_percent:.0f}% / {opt2_percent:.0f}%</span>'
 
                 row_cells.append(
-                    f'<td class="matrix-data-cell {highlight}" data-survey="{survey_id}">{cell_content}</td>'
+                    f'<td class="matrix-data-cell" data-survey="{survey_id}">{cell_content}</td>'
                 )
             else:
                 # User didn't participate in this survey
@@ -2597,8 +2602,7 @@ def generate_user_survey_matrix_html(performance_data: List[Dict]) -> str:
     <div class="matrix-container">
         <h2 class="matrix-title">{matrix_title}</h2>
         <div class="matrix-description">
-            <p>Matrix shows strategy-specific performance metrics for each user-survey combination. 
-            Highlighted cells indicate superior performance. "-" indicates no participation.</p>
+            <p>{matrix_description}</p>
         </div>
         <div class="matrix-table-wrapper">
             <table class="matrix-table">
@@ -2613,7 +2617,7 @@ def generate_user_survey_matrix_html(performance_data: List[Dict]) -> str:
             </table>
         </div>
         <div class="matrix-summary">
-            <p><strong>Users:</strong> {len(sorted_users)} | <strong>Surveys:</strong> {len(sorted_surveys)} | <strong>Total Responses:</strong> {len(performance_data)}</p>
+            <p><strong>{users_summary_label}:</strong> {len(sorted_users)} | <strong>{surveys_summary_label}:</strong> {len(sorted_surveys)} | <strong>{responses_summary_label}:</strong> {len(performance_data)}</p>
         </div>
     </div>
     """

--- a/application/services/pair_generation/rounded_weighted_average_vector.py
+++ b/application/services/pair_generation/rounded_weighted_average_vector.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Dict, Tuple
 
 import numpy as np
 
@@ -33,7 +33,8 @@ class RoundedWeightedAverageVectorStrategy(WeightedAverageVectorStrategy):
             weighted_vector: The weighted vector to be rounded.
 
         Returns:
-            np.ndarray: Rounded vector that sums to 100 with all values multiples of 5.
+            np.ndarray: Rounded vector that sums to 100 with all values
+            multiples of 5.
         """
         # First round everything to nearest multiple of 5
         rounded = np.round(weighted_vector / 5) * 5
@@ -63,7 +64,8 @@ class RoundedWeightedAverageVectorStrategy(WeightedAverageVectorStrategy):
             tuple: Rounded weighted combination vector
 
         Raises:
-            ValueError: If resulting vector is identical to either input vector
+            ValueError: If resulting vector is identical to either input
+            vector
         """
         self._validate_weight(x_weight)
         y_weight = 1 - x_weight
@@ -103,3 +105,25 @@ class RoundedWeightedAverageVectorStrategy(WeightedAverageVectorStrategy):
         if weight is None:
             return "Random Vector"
         return f"Rounded Weighted Average Vector: {int(weight * 100)}%"
+
+    def get_table_columns(self) -> Dict[str, Dict]:
+        """
+        Get column definitions for the rounded weighted average vector
+        response breakdown table.
+
+        Returns:
+            Dict with column definitions for Random and Weighted Average
+            options.
+        """
+        return {
+            "option1": {
+                "name": get_translation("random", "answers"),
+                "type": "percentage",
+                "highlight": True,
+            },
+            "option2": {
+                "name": get_translation("weighted_average", "answers"),
+                "type": "percentage",
+                "highlight": True,
+            },
+        }

--- a/application/services/pair_generation/weighted_average_vector.py
+++ b/application/services/pair_generation/weighted_average_vector.py
@@ -208,3 +208,23 @@ class WeightedAverageVectorStrategy(PairGenerationStrategy):
         if weight is None:
             return "Random Vector"
         return f"Average Weighted Vector: {int(weight * 100)}%"
+
+    def get_table_columns(self) -> Dict[str, Dict]:
+        """
+        Get column definitions for the weighted average vector response breakdown table.
+
+        Returns:
+            Dict with column definitions for Random and Weighted Average options.
+        """
+        return {
+            "option1": {
+                "name": get_translation("random", "answers"),
+                "type": "percentage",
+                "highlight": True,
+            },
+            "option2": {
+                "name": get_translation("weighted_average", "answers"),
+                "type": "percentage",
+                "highlight": True,
+            },
+        }

--- a/application/static/css/responses_style.css
+++ b/application/static/css/responses_style.css
@@ -1512,6 +1512,10 @@ th.sortable[data-order="desc"]::after {
    transition: background-color 0.2s ease;
 }
 
+.matrix-row:nth-child(odd) {
+   background-color: var(--color-background);
+}
+
 .matrix-row:nth-child(even) {
    background-color: var(--color-background-alt);
 }
@@ -1757,6 +1761,18 @@ th.sortable[data-order="desc"]::after {
 
 [dir="rtl"] .matrix-table {
    direction: rtl;
+}
+
+[dir="rtl"] .matrix-user-header {
+   left: auto;
+   right: 0;
+}
+
+[dir="rtl"] .matrix-user-cell {
+   left: auto;
+   right: 0;
+   border-right: none;
+   border-left: 2px solid var(--color-border);
 }
 
 

--- a/application/static/css/responses_style.css
+++ b/application/static/css/responses_style.css
@@ -369,13 +369,6 @@
     padding: 8px 4px;
 }
 
-/* Responsive design adjustments */
-@media (max-width: 768px) {
-    .ideal-budget-cell {
-        font-size: 0.8em;
-        padding: 4px 2px;
-    }
-}
 
 /* ==========================================================================
   Table Styles
@@ -1263,360 +1256,6 @@ th.sortable[data-order="desc"]::after {
     opacity: 0.6;
 }
 
-/* Responsive adjustments */
-@media (max-width: 768px) {
-    .survey-count-container {
-        gap: var(--spacing-xs);
-    }
-    
-    .survey-id-badge {
-        padding: 3px 6px;
-        font-size: 0.75rem;
-    }
-}
-
-
-/* ==========================================================================
-  RTL Support
-  ========================================================================== */
-/* Header & Content */
-[dir="rtl"] .survey-header {
-   align-items: flex-end;
-   text-align: right;
-   width: 100%;
-}
-
-[dir="rtl"] .survey-title,
-[dir="rtl"] .strategy-container,
-[dir="rtl"] .survey-description {
-   text-align: right;
-   width: 100%;
-}
-
-/* Tables */
-[dir="rtl"] .table-container th,
-[dir="rtl"] .table-container td {
-   text-align: right;
-}
-
-[dir="rtl"] .summary-note {
-   text-align: right;
-}
-
-[dir="rtl"] .selection-column {
-   text-align: center;
-}
-
-/* Filter Form */
-[dir="rtl"] .filter-form {
-   justify-content: flex-end;
-   align-items: flex-end;
-   width: 100%;
-   text-align: right;
-}
-
-[dir="rtl"] .filter-controls {
-   flex-direction: row-reverse;
-   justify-content: flex-end;
-   align-items: center;
-   text-align: right;
-   width: 100%;
-}
-
-[dir="rtl"] .filter-controls label {
-   margin-left: 10px;
-   margin-right: 0;
-   order: 2;
-}
-
-[dir="rtl"] .filter-controls select {
-   order: 1;
-}
-
-[dir="rtl"] .clear-filter {
-   margin-left: 0;
-   margin-right: 10px;
-}
-
-/* UI Elements */
-[dir="rtl"] .ideal-budget {
-   font-family: var(--font-family-mono);
-   direction: ltr;
-   display: inline-block;
-}
-
-[dir="rtl"] .raw-choice-info {
-   right: auto;
-   left: var(--spacing-sm);
-}
-
-[dir="rtl"] .back-icon {
-   transform: scaleX(-1);
-}
-
-[dir="rtl"] .back-link:hover {
-   transform: translateX(4px);
-}
-
-/* Tooltips */
-[dir="rtl"] .user-id-tooltip {
-   left: auto;
-   right: 50%;
-   transform: translateX(50%);
-}
-
-[dir="rtl"] .user-id-tooltip::after {
-   left: auto;
-   right: 50%;
-   margin-right: -5px;
-}
-
-/* Extreme Analysis Table */
-[dir="rtl"] .extreme-analysis-table .row-header {
-   text-align: center;
-}
-
-[dir="rtl"] .extreme-analysis-table th,
-[dir="rtl"] .extreme-analysis-table td {
-   text-align: center;
-}
-
-[dir="rtl"] .extreme-analysis-table .vector-info {
-   direction: ltr;
-   unicode-bidi: isolate;
-   text-align: center;
-   display: block;
-}
-
-[dir="rtl"] .extreme-analysis-table .group-label {
-   direction: rtl;
-   text-align: center;
-   display: block;
-}
-
-/* Percentile Breakdown Table */
-[dir="rtl"] .percentile-breakdown-container th,
-[dir="rtl"] .percentile-breakdown-container td {
-    text-align: center;
-}
-
-[dir="rtl"] .percentile-breakdown-container td:first-child {
-    text-align: center;
-}
-
-/* RTL Support for Cyclic Shift Consistency Table */
-[dir="rtl"] .cyclic-shift-consistency-container th,
-[dir="rtl"] .cyclic-shift-consistency-container td {
-    text-align: center;
-}
-
-[dir="rtl"] .cyclic-shift-consistency-container td:first-child {
-    text-align: right;
-    padding-right: 24px;
-    padding-left: var(--spacing-md);
-}
-
-[dir="rtl"] .cyclic-shift-consistency-container .overall-consistency td:first-child {
-    text-align: center;
-}
-
-/* Survey Count Containers */
-[dir="rtl"] .survey-count-container {
-   align-items: flex-end;
-}
-
-[dir="rtl"] .survey-ids-list {
-   flex-direction: row-reverse;
-   justify-content: flex-start;
-}
-
-[dir="rtl"] .ideal-budget {
-   text-align: center;
-}
-
-/* ==========================================================================
-  Responsive Adjustments
-  ========================================================================== */
-@media (max-width: 1024px) {
-   .comments-grid {
-      grid-template-columns: 1fr;
-      gap: 2rem;
-   }
-
-   .table-container {
-      margin: var(--spacing-sm) 0;
-   }
-}
-
-@media (max-width: 768px) {
-   .survey-header {
-      margin-bottom: var(--spacing-md);
-   }
-   
-   .survey-title {
-      font-size: 1.5rem;
-   }
-   
-   .filter-form {
-      flex-direction: column;
-      align-items: flex-start;
-      width: 100%;
-   }
-   
-   .filter-controls {
-      flex-direction: column;
-      align-items: flex-start;
-      width: 100%;
-   }
-   
-   .filter-controls select {
-      width: 100%;
-   }
-   
-   [dir="rtl"] .filter-form {
-      align-items: flex-end;
-   }
-   
-   [dir="rtl"] .filter-controls {
-      align-items: flex-end;
-   }
-   
-   [dir="rtl"] .filter-controls label {
-      margin-left: 0;
-      margin-bottom: 5px;
-   }
-   
-   .answers-container {
-      padding: var(--spacing-md);
-   }
-   
-   .choice-pair {
-      padding: var(--spacing-sm);
-   }
-
-   /* Percentile Breakdown Table */
-   .percentile-breakdown-container {
-      padding: var(--spacing-md);
-      margin: var(--spacing-lg) 0;
-  }
-
-  .percentile-breakdown-container table {
-      font-size: var(--font-size-sm);
-  }
-
-  .percentile-breakdown-container td,
-  .percentile-breakdown-container th {
-      padding: 8px;
-  }
-
-}
-
-@media (max-width: 480px) {
-  .answers-container {
-     padding: var(--spacing-sm);
-  }
-
-  .legend-container {
-     padding: var(--spacing-sm);
-  }
-
-  .comment-card {
-     padding: var(--spacing-md);
-  }
-
-  .survey-section h2 {
-     font-size: var(--font-size-lg);
-  }
-
-  .comment-header {
-     flex-direction: column;
-     gap: var(--spacing-xs);
-  }
-
-  .stats-title {
-     font-size: var(--font-size-xs);
-  }
-}
-
-/* ==========================================================================
- Print Styles
- ========================================================================== */
-@media print {
-  .answers-container {
-     max-width: none;
-     padding: 0;
-  }
-
-  .view-all-link {
-     display: none;
-  }
-
-  .comment-card {
-     break-inside: avoid;
-     box-shadow: none;
-     border: 1px solid #000;
-  }
-
-  .table-container {
-     overflow-x: visible;
-  }
-
-  .survey-section {
-     break-before: page;
-     box-shadow: none;
-  }
-
-  .comments-grid {
-     display: block;
-  }
-
-  .comment-card {
-     margin-bottom: var(--spacing-md);
-  }
-}
-
-/* ==========================================================================
- High Contrast Mode
- ========================================================================== */
-@media (prefers-contrast: high) {
-  .comment-card,
-  .legend-container,
-  .choice-pair,
-  .table-container {
-     border: 2px solid var(--color-text);
-  }
-
-  .table-container th {
-     background: #000;
-  }
-
-  .view-all-link {
-     background: #000;
-     border: 2px solid currentColor;
-  }
-
-  .highlight-row {
-     background-color: #000;
-     color: #fff;
-  }
-
-  .survey-response-link {
-     border: 2px solid currentColor;
-  }
-}
-
-/* ==========================================================================
- Reduced Motion
- ========================================================================== */
-@media (prefers-reduced-motion: reduce) {
-  .comment-card,
-  .view-all-link,
-  .back-to-top,
-  .survey-response-link {
-     transition: none;
-  }
-}
-
 /* Survey-level percentile breakdown table */
 .survey-percentile-breakdown-container {
     margin-top: 24px;
@@ -1790,34 +1429,589 @@ th.sortable[data-order="desc"]::after {
     border: 1px solid var(--color-border);
 }
 
-/* Responsive adjustments */
+
+/* ==========================================================================
+  User-Survey Matrix Styles
+  ========================================================================== */
+  .matrix-container {
+   max-width: 100%;
+   margin: var(--spacing-xl) 0;
+   padding: var(--spacing-lg);
+   background: var(--color-background-alt);
+   border-radius: 12px;
+   box-shadow: var(--shadow-md);
+}
+
+.matrix-title {
+   color: var(--color-primary);
+   font-size: var(--font-size-xl);
+   margin-bottom: var(--spacing-md);
+   text-align: center;
+}
+
+.matrix-description {
+   color: var(--color-text-light);
+   font-size: var(--font-size-sm);
+   margin-bottom: var(--spacing-lg);
+   text-align: center;
+   line-height: 1.6;
+}
+
+.matrix-table-wrapper {
+   overflow-x: auto;
+   border-radius: 8px;
+   box-shadow: var(--shadow-sm);
+   background: var(--color-background);
+}
+
+.matrix-table {
+   width: 100%;
+   min-width: 800px;
+   border-collapse: separate;
+   border-spacing: 0;
+   background: var(--color-background);
+}
+
+.matrix-header-row {
+   background: var(--color-primary);
+   color: white;
+}
+
+.matrix-user-header {
+   position: sticky;
+   left: 0;
+   background: var(--color-primary);
+   color: white;
+   padding: 16px 20px;
+   font-weight: 600;
+   text-align: center;
+   z-index: 3;
+   min-width: 120px;
+   max-width: 120px;
+}
+
+.matrix-survey-header {
+   background: var(--color-primary);
+   color: white;
+   padding: 16px 12px;
+   font-weight: 500;
+   text-align: center;
+   white-space: nowrap;
+   min-width: 100px;
+}
+
+.matrix-survey-header small {
+   display: block;
+   font-size: 0.85em;
+   opacity: 0.9;
+   margin-top: 4px;
+   font-weight: 400;
+}
+
+.matrix-row {
+   transition: background-color 0.2s ease;
+}
+
+.matrix-row:nth-child(even) {
+   background-color: var(--color-background-alt);
+}
+
+.matrix-row:hover {
+   background-color: rgba(52, 152, 219, 0.05);
+}
+
+.matrix-user-cell {
+   position: sticky;
+   left: 0;
+   background: inherit;
+   padding: 12px 16px;
+   border-right: 2px solid var(--color-border);
+   font-weight: 500;
+   z-index: 2;
+   min-width: 120px;
+   max-width: 120px;
+}
+
+.matrix-user-cell.truncated {
+   position: relative;
+}
+
+.matrix-data-cell {
+   padding: 12px;
+   text-align: center;
+   border-bottom: 1px solid var(--color-border);
+   vertical-align: middle;
+   min-width: 100px;
+}
+
+.matrix-data-cell.highlight-cell {
+   background-color: var(--color-highlight);
+   font-weight: 600;
+}
+
+.matrix-data-cell.no-participation {
+   background-color: rgba(0, 0, 0, 0.02);
+   color: var(--color-text-light);
+}
+
+.metric-value {
+   font-family: var(--font-family-mono);
+   font-weight: 600;
+   color: var(--color-primary);
+}
+
+.metric-pair {
+   font-family: var(--font-family-mono);
+   font-size: var(--font-size-sm);
+   display: block;
+   line-height: 1.4;
+}
+
+.no-data-indicator {
+   color: var(--color-text-light);
+   font-style: italic;
+   font-size: 1.2em;
+}
+
+.matrix-summary {
+   margin-top: var(--spacing-md);
+   padding: var(--spacing-md);
+   background: var(--color-background);
+   border-radius: 6px;
+   text-align: center;
+   color: var(--color-text-light);
+   font-size: var(--font-size-sm);
+}
+
+
+
+/* ==========================================================================
+  RTL Support
+  ========================================================================== */
+/* Header & Content */
+[dir="rtl"] .survey-header {
+   align-items: flex-end;
+   text-align: right;
+   width: 100%;
+}
+
+[dir="rtl"] .survey-title,
+[dir="rtl"] .strategy-container,
+[dir="rtl"] .survey-description {
+   text-align: right;
+   width: 100%;
+}
+
+/* Tables */
+[dir="rtl"] .table-container th,
+[dir="rtl"] .table-container td {
+   text-align: right;
+}
+
+[dir="rtl"] .summary-note {
+   text-align: right;
+}
+
+[dir="rtl"] .selection-column {
+   text-align: center;
+}
+
+/* Filter Form */
+[dir="rtl"] .filter-form {
+   justify-content: flex-end;
+   align-items: flex-end;
+   width: 100%;
+   text-align: right;
+}
+
+[dir="rtl"] .filter-controls {
+   flex-direction: row-reverse;
+   justify-content: flex-end;
+   align-items: center;
+   text-align: right;
+   width: 100%;
+}
+
+[dir="rtl"] .filter-controls label {
+   margin-left: 10px;
+   margin-right: 0;
+   order: 2;
+}
+
+[dir="rtl"] .filter-controls select {
+   order: 1;
+}
+
+[dir="rtl"] .clear-filter {
+   margin-left: 0;
+   margin-right: 10px;
+}
+
+/* UI Elements */
+[dir="rtl"] .ideal-budget {
+   font-family: var(--font-family-mono);
+   direction: ltr;
+   display: inline-block;
+}
+
+[dir="rtl"] .raw-choice-info {
+   right: auto;
+   left: var(--spacing-sm);
+}
+
+[dir="rtl"] .back-icon {
+   transform: scaleX(-1);
+}
+
+[dir="rtl"] .back-link:hover {
+   transform: translateX(4px);
+}
+
+/* Tooltips */
+[dir="rtl"] .user-id-tooltip {
+   left: auto;
+   right: 50%;
+   transform: translateX(50%);
+}
+
+[dir="rtl"] .user-id-tooltip::after {
+   left: auto;
+   right: 50%;
+   margin-right: -5px;
+}
+
+/* Extreme Analysis Table */
+[dir="rtl"] .extreme-analysis-table .row-header {
+   text-align: center;
+}
+
+[dir="rtl"] .extreme-analysis-table th,
+[dir="rtl"] .extreme-analysis-table td {
+   text-align: center;
+}
+
+[dir="rtl"] .extreme-analysis-table .vector-info {
+   direction: ltr;
+   unicode-bidi: isolate;
+   text-align: center;
+   display: block;
+}
+
+[dir="rtl"] .extreme-analysis-table .group-label {
+   direction: rtl;
+   text-align: center;
+   display: block;
+}
+
+/* Percentile Breakdown Table */
+[dir="rtl"] .percentile-breakdown-container th,
+[dir="rtl"] .percentile-breakdown-container td {
+    text-align: center;
+}
+
+[dir="rtl"] .percentile-breakdown-container td:first-child {
+    text-align: center;
+}
+
+/* RTL Support for Cyclic Shift Consistency Table */
+[dir="rtl"] .cyclic-shift-consistency-container th,
+[dir="rtl"] .cyclic-shift-consistency-container td {
+    text-align: center;
+}
+
+[dir="rtl"] .cyclic-shift-consistency-container td:first-child {
+    text-align: right;
+    padding-right: 24px;
+    padding-left: var(--spacing-md);
+}
+
+[dir="rtl"] .cyclic-shift-consistency-container .overall-consistency td:first-child {
+    text-align: center;
+}
+
+/* Survey Count Containers */
+[dir="rtl"] .survey-count-container {
+   align-items: flex-end;
+}
+
+[dir="rtl"] .survey-ids-list {
+   flex-direction: row-reverse;
+   justify-content: flex-start;
+}
+
+[dir="rtl"] .ideal-budget {
+   text-align: center;
+}
+
+[dir="rtl"] .matrix-user-header,
+[dir="rtl"] .matrix-user-cell {
+   right: 0;
+   left: auto;
+   border-left: 2px solid var(--color-border);
+   border-right: none;
+}
+
+[dir="rtl"] .matrix-table-wrapper {
+   direction: ltr;
+}
+
+[dir="rtl"] .matrix-table {
+   direction: rtl;
+}
+
+
+/* ==========================================================================
+  Responsive Adjustments
+  ========================================================================== */
+  @media (max-width: 1024px) {
+   .comments-grid {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+   }
+
+   .table-container {
+      margin: var(--spacing-sm) 0;
+   }
+}
+
 @media (max-width: 768px) {
-    .cyclic-shift-consistency-container {
-        padding: var(--spacing-md);
-    }
-    
-    .cyclic-shift-consistency-container table {
-        max-width: 100%;
-        font-size: var(--font-size-sm);
-    }
-    
-    .cyclic-shift-consistency-container th,
-    .cyclic-shift-consistency-container td {
-        padding: 12px 16px;
-    }
-    
-    .consistency-table-title {
-        font-size: var(--font-size-base);
-    }
+   .survey-header {
+      margin-bottom: var(--spacing-md);
+   }
+   
+   .survey-title {
+      font-size: 1.5rem;
+   }
+   
+   .filter-form {
+      flex-direction: column;
+      align-items: flex-start;
+      width: 100%;
+   }
+   
+   .filter-controls {
+      flex-direction: column;
+      align-items: flex-start;
+      width: 100%;
+   }
+   
+   .filter-controls select {
+      width: 100%;
+   }
+   
+   [dir="rtl"] .filter-form {
+      align-items: flex-end;
+   }
+   
+   [dir="rtl"] .filter-controls {
+      align-items: flex-end;
+   }
+   
+   [dir="rtl"] .filter-controls label {
+      margin-left: 0;
+      margin-bottom: 5px;
+   }
+   
+   .answers-container {
+      padding: var(--spacing-md);
+   }
+   
+   .choice-pair {
+      padding: var(--spacing-sm);
+   }
+
+   /* Percentile Breakdown Table */
+   .percentile-breakdown-container {
+      padding: var(--spacing-md);
+      margin: var(--spacing-lg) 0;
+  }
+
+  .percentile-breakdown-container table {
+      font-size: var(--font-size-sm);
+  }
+
+  .percentile-breakdown-container td,
+  .percentile-breakdown-container th {
+      padding: 8px;
+  }
+
+  .matrix-container {
+   padding: var(--spacing-md);
+   margin: var(--spacing-md) 0;
+   }
+
+   .matrix-table {
+      min-width: 600px;
+      font-size: var(--font-size-sm);
+   }
+
+   .matrix-user-header,
+   .matrix-user-cell {
+      min-width: 80px;
+      max-width: 80px;
+      padding: 8px 12px;
+   }
+
+   .matrix-survey-header {
+      min-width: 80px;
+      padding: 12px 8px;
+   }
+
+   .matrix-data-cell {
+      padding: 8px 6px;
+      min-width: 80px;
+   }
+
+   .metric-pair {
+      font-size: 0.8em;
+   }
+
+   .survey-count-container {
+      gap: var(--spacing-xs);
+  }
+  
+  .survey-id-badge {
+      padding: 3px 6px;
+      font-size: 0.75rem;
+  }
+
+  .ideal-budget-cell {
+   font-size: 0.8em;
+   padding: 4px 2px;
+}
+
+   .cyclic-shift-consistency-container {
+      padding: var(--spacing-md);
+   }
+
+   .cyclic-shift-consistency-container table {
+      max-width: 100%;
+      font-size: var(--font-size-sm);
+   }
+
+   .cyclic-shift-consistency-container th,
+   .cyclic-shift-consistency-container td {
+      padding: 12px 16px;
+   }
+
+   .consistency-table-title {
+      font-size: var(--font-size-base);
+   }
+
 }
 
 @media (max-width: 480px) {
-    .cyclic-shift-consistency-container th:first-child,
-    .cyclic-shift-consistency-container td:first-child {
-        padding-left: var(--spacing-md);
-    }
-    
-    .consistency-note {
-        font-size: var(--font-size-xs);
-    }
+  .answers-container {
+     padding: var(--spacing-sm);
+  }
+
+  .legend-container {
+     padding: var(--spacing-sm);
+  }
+
+  .comment-card {
+     padding: var(--spacing-md);
+  }
+
+  .survey-section h2 {
+     font-size: var(--font-size-lg);
+  }
+
+  .comment-header {
+     flex-direction: column;
+     gap: var(--spacing-xs);
+  }
+
+  .stats-title {
+     font-size: var(--font-size-xs);
+  }
+
+  .cyclic-shift-consistency-container th:first-child,
+  .cyclic-shift-consistency-container td:first-child {
+      padding-left: var(--spacing-md);
+  }
+  
+  .consistency-note {
+      font-size: var(--font-size-xs);
+  }
+
+}
+
+/* ==========================================================================
+ Print Styles
+ ========================================================================== */
+@media print {
+  .answers-container {
+     max-width: none;
+     padding: 0;
+  }
+
+  .view-all-link {
+     display: none;
+  }
+
+  .comment-card {
+     break-inside: avoid;
+     box-shadow: none;
+     border: 1px solid #000;
+  }
+
+  .table-container {
+     overflow-x: visible;
+  }
+
+  .survey-section {
+     break-before: page;
+     box-shadow: none;
+  }
+
+  .comments-grid {
+     display: block;
+  }
+
+  .comment-card {
+     margin-bottom: var(--spacing-md);
+  }
+}
+
+/* ==========================================================================
+ High Contrast Mode
+ ========================================================================== */
+@media (prefers-contrast: high) {
+  .comment-card,
+  .legend-container,
+  .choice-pair,
+  .table-container {
+     border: 2px solid var(--color-text);
+  }
+
+  .table-container th {
+     background: #000;
+  }
+
+  .view-all-link {
+     background: #000;
+     border: 2px solid currentColor;
+  }
+
+  .highlight-row {
+     background-color: #000;
+     color: #fff;
+  }
+
+  .survey-response-link {
+     border: 2px solid currentColor;
+  }
+}
+
+/* ==========================================================================
+ Reduced Motion
+ ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .comment-card,
+  .view-all-link,
+  .back-to-top,
+  .survey-response-link {
+     transition: none;
+  }
 }

--- a/application/templates/responses/users_matrix.html
+++ b/application/templates/responses/users_matrix.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block title %}{{ get_translation('user_survey_matrix', 'answers') }}{% endblock %}
+
+{% block additional_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/responses_style.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="answers-container">
+    <div class="answers-header">
+        <h1>{{ get_translation('user_survey_matrix', 'answers') }}</h1>
+        <div class="navigation-tabs">
+            <a href="{{ url_for('responses.get_users_overview') }}" class="tab">{{ get_translation('users_overview_tab', 'answers') }}</a>
+            <a href="{{ url_for('responses.users_matrix') }}" class="tab active">{{ get_translation('user_matrix_tab', 'answers') }}</a>
+        </div>
+    </div>
+    
+    <div class="answers-content">
+        {% if matrix_html %}
+            {{ matrix_html|safe }}
+        {% else %}
+            <p class="no-data">{{ get_translation('no_data_available', 'messages') }}</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}
+
+{% block floating_content %}
+<a href="#" id="back-to-top" class="back-to-top" aria-label="Back to top">↑</a>
+{% endblock %}
+
+{% block additional_scripts %}
+<script src="{{ url_for('static', filename='js/responses.js') }}"></script>
+{% endblock %} 

--- a/application/templates/responses/users_overview.html
+++ b/application/templates/responses/users_overview.html
@@ -9,7 +9,11 @@
 {% block content %}
 <div class="answers-container">
     <div class="answers-header">
-        <h1>{{ get_translation('user_participation_title', 'answers') }}</h1>
+        <h1>{{ get_translation('user_survey_matrix', 'answers') }}</h1>
+        <div class="navigation-tabs">
+            <a href="{{ url_for('responses.get_users_overview') }}" class="tab">{{ get_translation('users_overview_tab', 'answers') }}</a>
+            <a href="{{ url_for('responses.users_matrix') }}" class="tab active">{{ get_translation('user_matrix_tab', 'answers') }}</a>
+        </div>
     </div>
     
     <div class="answers-content">

--- a/application/templates/responses/users_overview.html
+++ b/application/templates/responses/users_overview.html
@@ -9,10 +9,10 @@
 {% block content %}
 <div class="answers-container">
     <div class="answers-header">
-        <h1>{{ get_translation('user_survey_matrix', 'answers') }}</h1>
+        <h1>{{ get_translation('user_participation_title', 'answers') }}</h1>
         <div class="navigation-tabs">
-            <a href="{{ url_for('responses.get_users_overview') }}" class="tab">{{ get_translation('users_overview_tab', 'answers') }}</a>
-            <a href="{{ url_for('responses.users_matrix') }}" class="tab active">{{ get_translation('user_matrix_tab', 'answers') }}</a>
+            <a href="{{ url_for('responses.get_users_overview') }}" class="tab active">{{ get_translation('users_overview_tab', 'answers') }}</a>
+            <a href="{{ url_for('responses.users_matrix') }}" class="tab">{{ get_translation('user_matrix_tab', 'answers') }}</a>
         </div>
     </div>
     

--- a/application/translations.py
+++ b/application/translations.py
@@ -132,6 +132,14 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
             "he": "המשתמש חסום מהשתתפות בסקרים עקב כישלון בבדיקת הערנות",
             "en": "User is blacklisted from participating in surveys due to failing attention checks",
         },
+        "no_data_available": {
+            "he": "אין נתונים זמינים להצגה",
+            "en": "No data available to display",
+        },
+        "matrix_generation_error": {
+            "he": "שגיאה ביצירת מטריצת המשתמשים",
+            "en": "Error generating the user matrix",
+        },
     },
     "survey": {  # Survey content
         "welcome": {"he": "ברוכים הבאים לסקר", "en": "Welcome to the Survey"},
@@ -574,6 +582,18 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
         "no_participation_data": {
             "he": "אין נתוני השתתפות",
             "en": "No participation data",
+        },
+        "user_survey_matrix": {
+            "he": "מטריצת ביצועי משתמשים",
+            "en": "User-Survey Performance Matrix",
+        },
+        "users_overview_tab": {
+            "he": "סקירת משתמשים",
+            "en": "Users Overview",
+        },
+        "user_matrix_tab": {
+            "he": "מטריצת ביצועים",
+            "en": "Performance Matrix",
         },
     },
 }

--- a/application/translations.py
+++ b/application/translations.py
@@ -544,8 +544,8 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
         "average_consistency": {"en": "Average Consistency", "he": "עקביות ממוצעת"},
         # Group consistency translations for cyclic shift
         "group_consistency": {
-            "he": "עקביות קבוצתית",
-            "en": "Group Consistency",
+            "he": "עקביות",
+            "en": "Consistency",
         },
         "group": {
             "he": "קבוצה",
@@ -594,6 +594,26 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
         "user_matrix_tab": {
             "he": "מטריצת ביצועים",
             "en": "Performance Matrix",
+        },
+        "matrix_description": {
+            "he": "מטריצה המציגה מדדי ביצוע ספציפיים עבור כל מענה לסקר. '-' מציין אי השתתפות.",
+            "en": "Matrix showing strategy-specific performance metrics for each user-survey combination. '-' indicates no participation.",
+        },
+        "matrix_summary_users": {
+            "he": "משתמשים",
+            "en": "Users",
+        },
+        "matrix_summary_surveys": {
+            "he": "סקרים",
+            "en": "Surveys",
+        },
+        "matrix_summary_total_responses": {
+            "he": "סך כל התשובות",
+            "en": "Total Responses",
+        },
+        "survey_label": {
+            "he": "סקר",
+            "en": "Survey",
         },
     },
 }


### PR DESCRIPTION
## Add User-Survey Performance Matrix View

Implements a comprehensive matrix table displaying user performance metrics across all surveys. Users can view strategy-specific results (consistency rates, sum/ratio percentages) for each user-survey combination in a single responsive table.

**Features:**
- Matrix table with users as rows, surveys as columns
- Strategy-specific metrics per survey type
- Responsive design with sticky user column
- Clear indicators for missing participation
- Navigation integration with existing survey views

**New Route:** `/surveys/users/matrix`