### PR TITLE
feat: Add customizable pair instructions for surveys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,8 +1015,12 @@ To add new surveys or modify existing ones, follow these steps:
        'budget_2024',
        TRUE,
        JSON_OBJECT(
-           'strategy', 'peak_linearity_test',
-           'params', JSON_OBJECT('num_pairs', 10)
+           'strategy', 'temporal_preference_test',
+           'params', JSON_OBJECT('num_pairs', 10),
+           'pair_instructions', JSON_OBJECT(
+               'he', 'עליכם לקבוע את התקציב עבור שתי שנים עוקבות: השנה הנוכחית, והשנה הבאה. איזה מבין שני התקציבים הבאים תעדיפו שיהיה התקציב בשנה הנוכחית? התקציב שלא תבחרו יהיה התקציב בשנה הבאה.',
+               'en', 'You need to set the budget for two consecutive years: the current year and next year. Which of the following two budgets would you prefer to be the current year''s budget? The budget you don''t choose will be next year''s budget.'
+           )
        )
    );
    ```
@@ -1062,6 +1066,62 @@ Remember to:
 - Include all required parameters for the chosen strategy
 - Update the `SURVEY_ID` in `config.py` after adding or modifying surveys
 - Ensure that story codes are unique across the stories table
+
+### Customizing Pair Instructions
+
+Surveys can include custom instructions for specific strategies. These instructions are stored in the `pair_instructions` field within the `pair_generation_config` JSON object and support both Hebrew and English languages. If no custom instructions are provided, the system will not display any instructions for that survey.
+
+#### Adding Custom Instructions to a New Survey
+
+```sql
+INSERT INTO surveys (
+    story_code,
+    active,
+    pair_generation_config
+)
+VALUES (
+    'my_custom_survey',
+    TRUE,
+    JSON_OBJECT(
+        'strategy', 'temporal_preference_test',
+        'params', JSON_OBJECT('num_pairs', 10),
+        'pair_instructions', JSON_OBJECT(
+            'he', 'הוראות מותאמות אישית בעברית',
+            'en', 'Custom personalized instructions in English'
+        )
+    )
+);
+```
+
+#### Updating Instructions for Existing Surveys
+
+```sql
+UPDATE surveys
+SET pair_generation_config = JSON_SET(
+    pair_generation_config,
+    '$.pair_instructions',
+    JSON_OBJECT(
+        'he', 'הוראות מעודכנות בעברית',
+        'en', 'Updated instructions in English'
+    )
+)
+WHERE id = 1;
+```
+
+#### Removing Custom Instructions
+
+To fall back to no instructions being displayed:
+
+```sql
+UPDATE surveys
+SET pair_generation_config = JSON_REMOVE(
+    pair_generation_config,
+    '$.pair_instructions'
+)
+WHERE id = 1;
+```
+
+**Note**: The `pair_instructions` field is optional. If omitted or set to `NULL`, no instructions will be displayed for that survey. This allows for flexible customization of the user experience.
 
 ### Changing Strategy Names and Colors
 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from flask import Flask, render_template
 from application.translations import get_current_language, get_translation
 from config import Config, get_config
 from database import db
+from database.queries import get_survey_instructions
 from logging_config import setup_logging
 
 load_dotenv()
@@ -45,6 +46,7 @@ def create_app(config_class: Optional[Type[Config]] = None) -> Flask:
         return {
             "get_current_language": get_current_language,
             "get_translation": get_translation,
+            "get_survey_instructions": get_survey_instructions,
         }
 
     # Register error handlers

--- a/application/templates/survey.html
+++ b/application/templates/survey.html
@@ -172,7 +172,10 @@ ENHANCED: Now includes UX improvements for ranking interface
                 {% if pair.is_awareness %}
                     <p class="temporal-instruction">{{ get_translation('temporal_awareness_instruction', 'survey') }}</p>
                 {% else %}
-                    <p class="temporal-instruction">{{ get_translation('temporal_pair_instruction', 'survey') }}</p>
+                    {% set custom_instruction = get_survey_instructions(internal_survey_id) %}
+                    {% if custom_instruction %}
+                        <p class="temporal-instruction">{{ custom_instruction }}</p>
+                    {% endif %}
                 {% endif %}
             {% endif %}
 

--- a/application/translations.py
+++ b/application/translations.py
@@ -381,10 +381,6 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
             "en": "Select rank",
         },
         # Temporal preference analysis
-        "temporal_pair_instruction": {
-            "he": "בחרו את התקציב לשנה הנוכחית. התקציב שלא תבחרו יהיה התקציב בשנה הבאה.",
-            "en": "Choose the budget for THIS year. The one you don't choose will be the budget for NEXT year.",
-        },
         "temporal_awareness_instruction": {
             "he": "זוהי בדיקת ערנות. אנא בחר את התקציב האידיאלי שלך.",
             "en": "This is an awareness check. Please select your ideal budget.",

--- a/migrations/20250907_add_strategy_instructions.sql
+++ b/migrations/20250907_add_strategy_instructions.sql
@@ -1,0 +1,15 @@
+-- Migration: Add pair instructions to pair_generation_config
+-- Date: 2025-09-07
+-- Description: Add pair_instructions field to existing temporal_preference_test surveys' pair_generation_config
+
+-- Update existing temporal_preference_test surveys to include default instructions in pair_generation_config
+UPDATE `surveys`
+SET `pair_generation_config` = JSON_SET(
+    `pair_generation_config`,
+    '$.pair_instructions',
+    JSON_OBJECT(
+        'he', 'עליכם לקבוע את התקציב עבור שתי שנים עוקבות: השנה הנוכחית, והשנה הבאה. איזה מבין שני התקציבים הבאים תעדיפו שיהיה התקציב בשנה הנוכחית? התקציב שלא תבחרו יהיה התקציב בשנה הבאה.',
+        'en', 'You need to set the budget for two consecutive years: the current year and next year. Which of the following two budgets would you prefer to be the current year''s budget? The budget you don''t choose will be next year''s budget.'
+    )
+)
+WHERE JSON_EXTRACT(`pair_generation_config`, '$.strategy') = 'temporal_preference_test';

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -85,3 +85,4 @@ In chronological order:
 - `20250514_add_weighted_vector_views.sql` - Creates SQL views for analyzing user preferences for weighted vector strategies
 - `20250616_add_option_differences.sql` - Adds option1_differences and option2_differences columns to comparison_pairs table for storing vector differences (used by cyclic shift strategy)
 - `20250806_add_transitivity_analysis.sql` - Adds transitivity_analysis JSON column to survey_responses table for storing transitivity metrics from extreme vectors strategy analysis
+- `20250907_add_strategy_instructions.sql` - Adds pair_instructions JSON column to surveys table for storing custom strategy instructions in Hebrew and English


### PR DESCRIPTION
- Move pair instructions from translations.py to database-driven configuration
- Add pair_instructions field to pair_generation_config JSON
- Create migration to add default instructions to existing temporal_preference_test surveys
- Update database queries, templates, and documentation
- Support multilingual (Hebrew/English) custom instructions per survey
- Maintain backward compatibility - no instructions shown when not configured