### PR TITLE
feat: Add CSV export for survey responses with filtering support

### DIFF
--- a/application/static/css/responses_style.css
+++ b/application/static/css/responses_style.css
@@ -1011,21 +1011,46 @@ th.sortable[data-order="desc"]::after {
 }
 
 .view-all-link {
-   display: inline-block;
-   padding: 0.75rem 1.5rem;
-   background-color: var(--color-primary);
-   color: white;
-   text-decoration: none;
-   border-radius: 6px;
-   font-weight: 500;
-   transition: all 0.2s ease;
-   margin: 1rem 0;
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background-color: var(--color-primary);
+  color: white;
+  text-decoration: none;
+  border-radius: 6px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  margin: 1rem 0;
 }
 
 .view-all-link:hover {
-   background-color: var(--color-primary-light);
-   transform: translateY(-1px);
-   box-shadow: var(--shadow-hover);
+  background-color: var(--color-primary-light);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-hover);
+}
+
+.view-all-link.download-csv-link {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  background-color: var(--color-secondary);
+}
+
+.view-all-link.download-csv-link:hover {
+  background-color: var(--color-primary);
+  transform: translateY(-2px);
+}
+
+/* Style for the new SVG icon */
+.download-csv-link .download-icon {
+    width: 1.2em;
+    height: 1.2em;
+    margin-inline-end: 0.5em; /* Handles spacing for both LTR and RTL */
+    vertical-align: middle;
+}
+
+/* Active state for better click feedback */
+.view-all-link.download-csv-link:active {
+  transform: translateY(1px);
+  background-color: var(--color-primary-light);
 }
 
 .comments-header {
@@ -2539,6 +2564,10 @@ th.sortable[data-order="desc"]::after {
    width: 100%;
 }
 
+[dir="rtl"] .survey-header .download-csv-link {
+   align-self: flex-start;
+}
+
 /* Tables */
 [dir="rtl"] .table-container th,
 [dir="rtl"] .table-container td {
@@ -2737,16 +2766,16 @@ th.sortable[data-order="desc"]::after {
 
 /* Survey Count Containers */
 [dir="rtl"] .survey-count-container {
-   align-items: flex-end;
+  align-items: flex-end;
 }
 
 [dir="rtl"] .survey-ids-list {
-   flex-direction: row-reverse;
-   justify-content: flex-start;
+  flex-direction: row-reverse;
+  justify-content: flex-start;
 }
 
 [dir="rtl"] .ideal-budget {
-   text-align: center;
+  text-align: center;
 }
 
 [dir="rtl"] .matrix-user-header,

--- a/application/templates/responses/detail.html
+++ b/application/templates/responses/detail.html
@@ -12,6 +12,29 @@
 <div class="container responses-container">
     <div class="survey-header">
         <h1 class="survey-title">{{ get_translation("survey_response_title", "answers", survey_id=survey_id) }}</h1>
+
+        <a href="{{ url_for('responses.download_survey_responses_csv', survey_id=survey_id, view_filter=request.args.get('view_filter')) }}"
+           class="view-all-link download-csv-link"
+           title="{{ get_translation('download_csv_tooltip', 'answers', default='Download all survey responses as CSV file') }}">
+            {% set icon_svg %}
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="download-icon">
+                    <path d="M10.75 2.75a.75.75 0 00-1.5 0v8.614L6.295 8.235a.75.75 0 10-1.09 1.03l4.25 4.5a.75.75 0 001.09 0l4.25-4.5a.75.75 0 00-1.09-1.03l-2.955 3.129V2.75z" />
+                    <path d="M3.5 12.75a.75.75 0 00-1.5 0v2.5A2.75 2.75 0 004.75 18h10.5A2.75 2.75 0 0018 15.25v-2.5a.75.75 0 00-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5z" />
+                </svg>
+            {% endset %}
+
+            {% set button_text %}
+                <span>{{ get_translation('download_csv', 'answers', default='Download CSV') }}</span>
+            {% endset %}
+
+            {% if get_current_language() == 'he' %}
+                {{ button_text|safe }}
+                {{ icon_svg|safe }}
+            {% else %}
+                {{ icon_svg|safe }}
+                {{ button_text|safe }}
+            {% endif %}
+        </a>
         
         {% if strategy_name %}
         <div class="strategy-container">

--- a/application/translations.py
+++ b/application/translations.py
@@ -144,6 +144,10 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
             "he": "שגיאה ביצירת מטריצת המשתמשים",
             "en": "Error generating the user matrix",
         },
+        "no_responses_to_download": {
+            "he": "אין תשובות זמינות להורדה עבור סקר {survey_id}",
+            "en": "No responses available for download for survey {survey_id}",
+        },
     },
     "pagination": {  # Pagination controls
         "previous": {
@@ -560,6 +564,14 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
         "clear_filter": {
             "he": "נקה סינון",
             "en": "Clear",
+        },
+        "download_csv": {
+            "he": "הורד CSV",
+            "en": "Download CSV",
+        },
+        "download_csv_tooltip": {
+            "he": "הורד את נתוני התשובות בפורמט CSV",
+            "en": "Download response data in CSV format",
         },
         "comments_title": {"he": "הערות המשתמשים", "en": "User Comments"},
         "view_all_comments": {"he": "צפה בכל ההערות", "en": "View All Comments"},

--- a/database/queries.py
+++ b/database/queries.py
@@ -452,6 +452,7 @@ def retrieve_user_survey_choices() -> List[Dict]:
     SELECT 
         sr.user_id,
         sr.survey_id,
+        sr.id as survey_response_id,
         sr.optimal_allocation,
         sr.created_at as response_created_at,
         cp.pair_number,


### PR DESCRIPTION
- Add download button to survey responses page
- Implement CSV download endpoint with view filter support
- Include survey_response_id in exported data
- Add comprehensive test coverage
- Support dynamic filenames based on survey ID and filters
- Add Hebrew/English translations for UI elements