### PR TITLE
Feat: Add Client-Side Response Time Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This is a **research application** for studying budget allocation preferences. I
 - Multiple research-validated pair generation strategies
 - Hebrew/English multilingual support with RTL/LTR layouts
 - Quality control via attention checks and user blacklisting
+- Cognitive load tracking via client-side response time measurement
 - Comprehensive analysis and PDF report generation
 - Production-ready Docker deployment
 
@@ -727,6 +728,15 @@ The application includes a user blacklist feature to automatically enforce quali
     - `failed_survey_id` identifies which survey triggered the blacklist
   - Indexed for efficient lookups during eligibility checks
 
+### Cognitive Load Tracking
+
+The application measures the "cognitive load" users experience by tracking their total response time:
+
+- **Client-Side Measurement**: Time is measured entirely client-side using `performance.now()` from the moment the survey page fully loads (`DOMContentLoaded`) until the user clicks the final submit button.
+- **Accuracy**: This approach isolates the actual time the user spends thinking and interacting with the UI, eliminating inaccuracies caused by network latency or server processing times.
+- **Data Export**: The total response time (in seconds) is stored in the database and included in the CSV data exports for academic analysis.
+- **Exclusions**: Response times are only recorded for successful, completed surveys. Early failures or unsuitability rejections do not record a response time.
+
 ### Demo Mode
 
 The application includes a 'Demo Mode' feature that allows users to explore the survey functionality without affecting the actual data.
@@ -863,6 +873,7 @@ If a user submits a vector violating these rules, the system raises an `Unsuitab
 - Run in order:
   - `python migrations/run_migration.py migrations/20251204_add_pts_value_column.sql`
   - `python migrations/run_migration.py migrations/20251204_add_survey_response_uniqueness.sql`
+  - `python migrations/run_migration.py migrations/20260414_add_total_response_time.sql`
 - Note: The uniqueness migration will fail if duplicates already exist for `(user_id, survey_id)`; clean them first if needed.
 
 ## Docker Guide

--- a/analysis/presentation/html_renderers.py
+++ b/analysis/presentation/html_renderers.py
@@ -24,6 +24,10 @@ from analysis.logic.stats_calculators import (
 from analysis.transitivity_analyzer import TransitivityAnalyzer
 from analysis.utils import is_sum_optimized
 from application.translations import get_translation
+from config import get_config
+
+# Initialize config
+config = get_config()
 
 logger = logging.getLogger(__name__)
 
@@ -1684,13 +1688,27 @@ def generate_detailed_breakdown_table(
             }
 
         # 3. Sort Logic
-        key_map = {"user_id": "user_id", "created_at": "response_created_at"}
+        key_map = {
+            "user_id": "user_id",
+            "created_at": "response_created_at",
+            "duration": "duration",
+        }
         sort_key = key_map.get(sort_by, "response_created_at")
         reverse = (sort_order.lower() == "desc") if sort_by else True
 
-        sorted_summaries = sorted(
-            survey_summaries, key=lambda x: x.get(sort_key, "") or "", reverse=reverse
-        )
+        def get_sort_value(x):
+            if sort_key == "duration":
+                # Handle duration sorting: extract from choices and handle None
+                choices = x.get("choices", [])
+                val = choices[0].get("total_response_time_seconds") if choices else None
+                return (
+                    float(val)
+                    if val is not None
+                    else (float("-inf") if reverse else float("inf"))
+                )
+            return x.get(sort_key, "") or ""
+
+        sorted_summaries = sorted(survey_summaries, key=get_sort_value, reverse=reverse)
 
         # 4. Generate Rows
         rows = []
@@ -1706,6 +1724,31 @@ def generate_detailed_breakdown_table(
 
             timestamp = _format_timestamp(summary.get("response_created_at"))
             ideal_budget = _format_ideal_budget(summary.get("choices", []))
+
+            # Handle Response Time (Duration)
+            choices = summary.get("choices", [])
+            duration_val = (
+                choices[0].get("total_response_time_seconds") if choices else None
+            )
+            if duration_val is not None:
+                duration_seconds = round(float(duration_val))
+                duration_display = f"{duration_seconds}s"
+
+                # Threshold for suspiciously fast responses
+                is_suspicious = (
+                    duration_seconds < config.SUSPICIOUS_RESPONSE_TIME_THRESHOLD_SECONDS
+                )
+
+                duration_class = "suspicious-time" if is_suspicious else ""
+                duration_title = (
+                    get_translation("suspiciously_fast", "answers")
+                    if is_suspicious
+                    else ""
+                )
+            else:
+                duration_display = "N/A"
+                duration_class = ""
+                duration_title = ""
 
             # Generic Cell Generation
             data_cells = _generate_strategy_data_cells(summary, strategy_columns)
@@ -1733,6 +1776,7 @@ def generate_detailed_breakdown_table(
                     {tooltip}
                 </td>
                 <td>{timestamp}</td>
+                <td class="duration-cell {duration_class}" title="{duration_title}">{duration_display}</td>
                 <td class="ideal-budget-cell">{ideal_budget}</td>
                 {"".join(data_cells)}
                 {view_cell}
@@ -1753,7 +1797,8 @@ def generate_detailed_breakdown_table(
         trans = {
             "title": get_translation("survey_response_breakdown", "answers"),
             "user": get_translation("user_id", "answers"),
-            "time": get_translation("response_time", "answers"),
+            "time": get_translation("submitted_at", "answers"),
+            "duration": get_translation("duration", "answers"),
             "budget": get_translation("ideal_budget", "answers"),
             "view": get_translation("view_response", "answers"),
         }
@@ -1767,6 +1812,7 @@ def generate_detailed_breakdown_table(
                         <tr>
                             <th class="sortable" data-sort="user_id"{get_sort_attr('user_id')}>{trans['user']}</th>
                             <th class="sortable" data-sort="created_at"{get_sort_attr('created_at')}>{trans['time']}</th>
+                            <th class="sortable" data-sort="duration"{get_sort_attr('duration')}>{trans['duration']}</th>
                             <th>{trans['budget']}</th>
                             {"".join(header_cells)}
                             <th>{trans['view']}</th>

--- a/analysis/presentation/html_renderers.py
+++ b/analysis/presentation/html_renderers.py
@@ -599,9 +599,25 @@ def generate_survey_choices_html(
     html_parts = [
         '<div class="survey-choices">',
         f"<h4>{survey_id_label}: {survey_id}</h4>",
-        f'<div class="ideal-budget">{ideal_budget_label}: '
-        f"{optimal_allocation}</div>",
+        '<div class="metadata-row" style="display: flex; gap: 1rem; align-items: center; margin-bottom: 1.5rem;">',
+        f'<div class="ideal-budget">{ideal_budget_label}: {optimal_allocation}</div>',
     ]
+
+    # Add Response Time badge if available
+    total_response_time = first_choice.get("total_response_time_seconds")
+    if total_response_time is not None:
+        rounded_time = round(float(total_response_time))
+        response_time_label = get_translation("response_time", "answers")
+        html_parts.append(
+            f'<div class="ideal-budget" title="Total time spent on the survey page">⏱️ {response_time_label}: {rounded_time}s</div>'
+        )
+    else:
+        response_time_label = get_translation("response_time", "answers")
+        html_parts.append(
+            f'<div class="ideal-budget" title="Time not recorded (e.g., legacy data or early failure)">⏱️ {response_time_label}: N/A</div>'
+        )
+
+    html_parts.append("</div>")
 
     # Special handling for peak_linearity_test strategy
     if strategy_name == "peak_linearity_test":

--- a/application/routes/survey_responses.py
+++ b/application/routes/survey_responses.py
@@ -477,6 +477,9 @@ def download_survey_responses_csv(survey_id: int):
                     "user_id": choice.get("user_id"),
                     "survey_response_id": choice.get("survey_response_id"),
                     "response_created_at": choice.get("response_created_at"),
+                    "total_response_time_seconds": choice.get(
+                        "total_response_time_seconds"
+                    ),
                     "optimal_allocation": str(choice.get("optimal_allocation")),
                     "pair_number": choice.get("pair_number"),
                     "pair_score": pair_score,

--- a/application/routes/survey_responses.py
+++ b/application/routes/survey_responses.py
@@ -51,7 +51,7 @@ def validate_sort_params(sort_by, sort_order):
     Returns:
         tuple: (valid_sort_by, valid_sort_order)
     """
-    allowed_sort_fields = ["user_id", "created_at"]
+    allowed_sort_fields = ["user_id", "created_at", "duration"]
     allowed_sort_orders = ["asc", "desc"]
 
     valid_sort_by = sort_by if sort_by in allowed_sort_fields else None
@@ -171,6 +171,17 @@ def get_user_responses(
                     user_choices.sort(
                         key=lambda x: x["response_created_at"], reverse=reverse
                     )
+                elif sort_by == "duration":
+                    # Handle None values by putting them at the end
+                    def get_duration(x):
+                        val = x.get("total_response_time_seconds")
+                        return (
+                            float(val)
+                            if val is not None
+                            else (float("-inf") if reverse else float("inf"))
+                        )
+
+                    user_choices.sort(key=get_duration, reverse=reverse)
 
             # Handle the case where we have a view filter but no matching
             # choices for the survey
@@ -358,6 +369,20 @@ def get_survey_responses(survey_id: int):
             view_filter=view_filter,
         )
 
+        # Calculate average response time
+        avg_response_time = None
+        if data.get("responses"):
+            # We need to get unique users and their response times
+            user_times = {}
+            for response in data["responses"]:
+                user_id = response.get("user_id")
+                time = response.get("total_response_time_seconds")
+                if user_id and time is not None and user_id not in user_times:
+                    user_times[user_id] = float(time)
+
+            if user_times:
+                avg_response_time = sum(user_times.values()) / len(user_times)
+
         # Fetch the survey description
         survey_description = get_survey_description(survey_id)
 
@@ -410,6 +435,7 @@ def get_survey_responses(survey_id: int):
             strategy_name=strategy_name,
             view_filter=view_filter,
             percentile_breakdown=percentile_breakdown,
+            avg_response_time=avg_response_time,
         )
 
     except SurveyNotFoundError as e:

--- a/application/schemas/validators.py
+++ b/application/schemas/validators.py
@@ -68,6 +68,7 @@ class SurveySubmission:
     survey_id: int
     user_vector: List[int] = field(default_factory=list)
     user_comment: Optional[str] = ""
+    total_response_time_seconds: Optional[float] = None
     awareness_answers: List[Union[int, str]] = field(default_factory=list)
     comparison_pairs: List[ComparisonPair] = field(default_factory=list)
     expected_pairs: int = 10  # Default for backward compatibility
@@ -443,11 +444,23 @@ class SurveySubmission:
                 pairs[0].generation_metadata if pairs else None,
             )
 
+            # Parse total_response_time_seconds
+            total_response_time_seconds = None
+            total_response_time_str = form_data.get("total_response_time_seconds", "")
+            if total_response_time_str:
+                try:
+                    total_response_time_seconds = float(total_response_time_str)
+                except ValueError:
+                    logger.warning(
+                        f"Invalid total_response_time_seconds: {total_response_time_str}"
+                    )
+
             return cls(
                 user_id=user_id,
                 survey_id=survey_id,
                 user_vector=user_vector,
                 user_comment=form_data.get("user_comment", "").strip(),
+                total_response_time_seconds=total_response_time_seconds,
                 awareness_answers=awareness_answers,
                 comparison_pairs=pairs,
                 expected_pairs=expected_pairs,

--- a/application/services/survey_service.py
+++ b/application/services/survey_service.py
@@ -513,6 +513,9 @@ class SurveyService:
         Process and store a survey submission.
         Creates user if needed, stores responses, and marks survey as complete.
 
+        Note: Early awareness failures and unsuitability rejections do not reach this logic,
+        so their total_response_time_seconds will correctly remain NULL in the database.
+
         Args:
             submission: Validated survey submission data
             attention_check_failed: Whether the submission failed attention checks
@@ -533,6 +536,8 @@ class SurveyService:
                 submission.user_vector,
                 submission.user_comment,
                 attention_check_failed,
+                unsuitable_for_strategy=False,
+                total_response_time_seconds=submission.total_response_time_seconds,
             )
             logger.info(
                 f"Created survey response: {survey_response_id} "

--- a/application/static/css/responses_style.css
+++ b/application/static/css/responses_style.css
@@ -49,6 +49,9 @@
    --color-orange: #F97316;  /* Orange for partial consistency */
    --color-danger: #DC2626;  /* Darker red for danger */
    
+   /* Suspicious Time Color */
+   --color-suspicious: #DC2626; /* Red for suspiciously fast times */
+   
    /* Pagination Colors */
    --pagination-background: #ffffff;
    --pagination-border: #dee2e6;
@@ -56,6 +59,28 @@
    --pagination-active: var(--color-primary);
    --pagination-disabled: #6c757d;
    --pagination-text: var(--color-text);
+}
+
+/* ==========================================================================
+   Suspicious Time Highlighting
+   ========================================================================== */
+.duration-cell {
+    text-align: center;
+}
+
+.suspicious-time {
+    color: var(--color-suspicious);
+    font-weight: 600;
+}
+.suspicious-time::before {
+    content: "⚠️ ";
+    font-size: 0.9em;
+}
+
+.duration-badge {
+    background-color: var(--color-background-alt);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
 }
 
 /* ==========================================================================

--- a/application/static/js/survey.js
+++ b/application/static/js/survey.js
@@ -383,6 +383,9 @@ function initializeSurveyForm() {
         return;
     }
 
+    // Initialize response time tracking
+    initializeResponseTimeTracking(form, submitBtn);
+
     // Check if this is a ranking-based survey
     const rankingQuestions = document.querySelectorAll('.ranking-question');
     if (rankingQuestions.length > 0) {
@@ -407,6 +410,29 @@ function initializeSurveyForm() {
     
     // Setup live awareness check detection
     setupAwarenessLiveChecks();
+}
+
+/**
+ * Initialize response time tracking
+ */
+function initializeResponseTimeTracking(form, submitBtn) {
+    const startTime = performance.now();
+    const responseTimeInput = document.getElementById("response_time_input");
+
+    if (!responseTimeInput) return;
+
+    function updateResponseTime() {
+        const endTime = performance.now();
+        const deltaSeconds = (endTime - startTime) / 1000;
+        responseTimeInput.value = deltaSeconds.toFixed(3);
+    }
+
+    // Update on hover/focus to ensure value is captured before any potential submit event interception
+    submitBtn.addEventListener("mouseenter", updateResponseTime);
+    submitBtn.addEventListener("focus", updateResponseTime);
+    
+    // Also update on actual submit as a fallback
+    form.addEventListener("submit", updateResponseTime);
 }
 
 /**

--- a/application/templates/responses/detail.html
+++ b/application/templates/responses/detail.html
@@ -44,6 +44,12 @@
                   title="{{ strategy_name | replace('_', ' ') | title }}">
                 {{ strategy_name | replace('_', ' ') | title }}
             </span>
+            
+            {% if avg_response_time is not none %}
+            <span class="strategy-badge duration-badge" title="Average time spent on the survey page">
+                ⏱️ {{ get_translation('avg_duration', 'answers') }}: {{ avg_response_time|round|int }}s
+            </span>
+            {% endif %}
         </div>
         {% endif %}
         

--- a/application/templates/survey.html
+++ b/application/templates/survey.html
@@ -46,6 +46,8 @@ ENHANCED: Now includes UX improvements for ranking interface
         <input type="hidden" name="q" value="{{ external_q_argument }}">
         {% endif %}
         
+        <input type="hidden" name="total_response_time_seconds" id="response_time_input" value="">
+        
         {% if is_ranking_based %}
         <!-- Ranking-based survey: Show ranking questions -->
         {% for question in ranking_questions %}
@@ -334,7 +336,7 @@ ENHANCED: Now includes UX improvements for ranking interface
 
         <div id="error-message" class="error-message" style="display: none;" role="alert" aria-live="polite"></div>
         <div class="submit-container">
-            <button type="submit" class="btn" aria-label="Submit completed survey">{{ get_translation('submit_final') }}</button>
+            <button type="submit" id="survey-submit-button" class="btn" aria-label="Submit completed survey">{{ get_translation('submit_final') }}</button>
         </div>
     </form>
 </div>

--- a/application/translations.py
+++ b/application/translations.py
@@ -722,7 +722,7 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
         "metric": {"he": "מדד", "en": "Metric"},
         "percentage": {"he": "אחוז", "en": "Percentage"},
         "choice": {"he": "בחירה", "en": "Choice"},
-        "response_time": {"he": "זמן תגובה", "en": "Response Time"},
+        "response_time": {"he": "זמן מענה", "en": "Response Time"},
         # Identifiers and metadata
         "survey_id": {"he": "מזהה סקר", "en": "Survey ID"},
         "user_id": {"he": "מזהה משתמש", "en": "User ID"},

--- a/application/translations.py
+++ b/application/translations.py
@@ -723,6 +723,13 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
         "percentage": {"he": "אחוז", "en": "Percentage"},
         "choice": {"he": "בחירה", "en": "Choice"},
         "response_time": {"he": "זמן מענה", "en": "Response Time"},
+        "duration": {"he": "משך זמן", "en": "Duration"},
+        "submitted_at": {"he": "הוגש ב-", "en": "Submitted At"},
+        "avg_duration": {"he": "משך זמן ממוצע", "en": "Avg. Duration"},
+        "suspiciously_fast": {
+            "he": "זמן מענה מהיר באופן חשוד. עשוי להעיד על בחירות אקראיות.",
+            "en": "Suspiciously fast response time. May indicate random clicking.",
+        },
         # Identifiers and metadata
         "survey_id": {"he": "מזהה סקר", "en": "Survey ID"},
         "user_id": {"he": "מזהה משתמש", "en": "User ID"},

--- a/config.py
+++ b/config.py
@@ -22,6 +22,7 @@ class Config:
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
 
     PAGINATION_PER_PAGE: int = 10
+    SUSPICIOUS_RESPONSE_TIME_THRESHOLD_SECONDS: int = 60
 
     # Security settings
     SECRET_KEY = os.getenv(

--- a/database/queries.py
+++ b/database/queries.py
@@ -39,6 +39,7 @@ def create_survey_response(
     user_comment: str,
     attention_check_failed: bool = False,
     unsuitable_for_strategy: bool = False,
+    total_response_time_seconds: Optional[float] = None,
 ) -> int:
     """
     Inserts a new survey response into the survey_responses table.
@@ -50,19 +51,20 @@ def create_survey_response(
         user_comment (str): The user's comment on the survey.
         attention_check_failed (bool): Whether the user failed the attention check.
         unsuitable_for_strategy (bool): Whether user was unsuitable for strategy.
+        total_response_time_seconds (Optional[float]): Total time spent on the survey page.
 
     Returns:
         int: The ID of the newly created survey response, or None if an error occurs.
     """
     query = """
         INSERT INTO survey_responses 
-        (user_id, survey_id, optimal_allocation, user_comment, attention_check_failed, unsuitable_for_strategy)
-        VALUES (%s, %s, %s, %s, %s, %s)
+        (user_id, survey_id, optimal_allocation, user_comment, attention_check_failed, unsuitable_for_strategy, total_response_time_seconds)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
     """
     optimal_allocation_json = json.dumps(optimal_allocation)
     logger.debug(
         f"Inserting survey response for user_id: {user_id}, survey_id: {survey_id}, "
-        f"unsuitable: {unsuitable_for_strategy}"
+        f"unsuitable: {unsuitable_for_strategy}, total_response_time: {total_response_time_seconds}"
     )
 
     try:
@@ -75,6 +77,7 @@ def create_survey_response(
                 user_comment,
                 attention_check_failed,
                 unsuitable_for_strategy,
+                total_response_time_seconds,
             ),
         )
     except Exception as e:
@@ -498,6 +501,7 @@ def retrieve_completed_survey_responses() -> List[Dict]:
         sr.optimal_allocation,
         sr.completed,
         sr.created_at AS response_created_at,
+        sr.total_response_time_seconds,
         COALESCE(sr.user_comment, '') as user_comment,
         cp.pair_number,
         cp.option_1,
@@ -598,6 +602,7 @@ def retrieve_user_survey_choices() -> List[Dict]:
         sr.id as survey_response_id,
         sr.optimal_allocation,
         sr.created_at as response_created_at,
+        sr.total_response_time_seconds,
         cp.pair_number,
         cp.option_1,
         cp.option_2,

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -66,6 +66,7 @@ CREATE TABLE `survey_responses` (
   `user_comment` TEXT DEFAULT NULL,
   `completed` BOOLEAN DEFAULT FALSE,
   `attention_check_failed` BOOLEAN DEFAULT FALSE,
+  `total_response_time_seconds` FLOAT DEFAULT NULL COMMENT 'Total time spent on the survey page in seconds',
   `pts_value` INT DEFAULT NULL COMMENT 'Awareness failure code (1=first awareness, 2=second awareness)',
   `transitivity_analysis` JSON DEFAULT NULL COMMENT 'Transitivity metrics for extreme vector responses',
   `unsuitable_for_strategy` BOOLEAN DEFAULT FALSE COMMENT 'Indicates if user vector was unsuitable for pair generation strategy',

--- a/instrument-fix.py
+++ b/instrument-fix.py
@@ -1,0 +1,69 @@
+def patch_file():
+    path = "/Users/liozakirav/Documents/Projects/budget-survey/analysis/presentation/html_renderers.py"
+    with open(path, "r") as f:
+        content = f.read()
+
+    target = """        # region agent log
+        import json
+        with open("/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log", "a") as f:"""
+
+    replacement = """        # region agent log
+        import json
+        import os
+        log_dir = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor"
+        if not os.path.exists(log_dir):
+            try:
+                os.makedirs(log_dir, exist_ok=True)
+            except Exception:
+                pass
+        
+        # In Docker, the path might be different, let's try a relative path or stdout fallback
+        log_path = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log"
+        try:
+            with open(log_path, "a") as f:"""
+
+    if target in content:
+        content = content.replace(target, replacement)
+
+        # We also need to fix the indentation for the rest of the block
+        content = content.replace(
+            """            f.write(json.dumps({
+                "sessionId": "363d07",
+                "runId": "post-fix",
+                "hypothesisId": "H1",
+                "location": "html_renderers.py:generate_detailed_breakdown_table",
+                "message": "Final sorted summaries",
+                "data": {
+                    "sort_by": sort_by, 
+                    "sort_key": sort_key, 
+                    "reverse": reverse,
+                    "order": [(s["user_id"], s.get("choices", [{}])[0].get("total_response_time_seconds")) for s in sorted_summaries]
+                }
+            }) + "\\n")
+        # endregion""",
+            """                f.write(json.dumps({
+                    "sessionId": "363d07",
+                    "runId": "post-fix",
+                    "hypothesisId": "H1",
+                    "location": "html_renderers.py:generate_detailed_breakdown_table",
+                    "message": "Final sorted summaries",
+                    "data": {
+                        "sort_by": sort_by, 
+                        "sort_key": sort_key, 
+                        "reverse": reverse,
+                        "order": [(s["user_id"], s.get("choices", [{}])[0].get("total_response_time_seconds")) for s in sorted_summaries]
+                    }
+                }) + "\\n")
+        except Exception as e:
+            print(f"DEBUG LOG ERROR: {e}")
+        # endregion""",
+        )
+
+        with open(path, "w") as f:
+            f.write(content)
+        print("Patched html_renderers.py successfully")
+    else:
+        print("Target not found in html_renderers.py")
+
+
+patch_file()

--- a/instrument-fix2.py
+++ b/instrument-fix2.py
@@ -1,0 +1,63 @@
+def patch_file():
+    path = "/Users/liozakirav/Documents/Projects/budget-survey/application/routes/survey_responses.py"
+    with open(path, "r") as f:
+        content = f.read()
+
+    target = """                    # region agent log
+                    import json
+                    with open("/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log", "a") as f:"""
+
+    replacement = """                    # region agent log
+                    import json
+                    import os
+                    log_dir = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor"
+                    if not os.path.exists(log_dir):
+                        try:
+                            os.makedirs(log_dir, exist_ok=True)
+                        except Exception:
+                            pass
+                    
+                    log_path = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log"
+                    try:
+                        with open(log_path, "a") as f:"""
+
+    if target in content:
+        content = content.replace(target, replacement)
+
+        content = content.replace(
+            """                        f.write(json.dumps({
+                            "sessionId": "363d07",
+                            "hypothesisId": "H1",
+                            "location": "survey_responses.py:get_user_responses",
+                            "message": "Sorted user_choices",
+                            "data": {
+                                "sort_by": sort_by,
+                                "reverse": reverse,
+                                "order": [(c["user_id"], c.get("total_response_time_seconds")) for c in user_choices[:10]]
+                            }
+                        }) + "\\n")
+                    # endregion""",
+            """                            f.write(json.dumps({
+                                "sessionId": "363d07",
+                                "hypothesisId": "H1",
+                                "location": "survey_responses.py:get_user_responses",
+                                "message": "Sorted user_choices",
+                                "data": {
+                                    "sort_by": sort_by,
+                                    "reverse": reverse,
+                                    "order": [(c["user_id"], c.get("total_response_time_seconds")) for c in user_choices[:10]]
+                                }
+                            }) + "\\n")
+                    except Exception as e:
+                        print(f"DEBUG LOG ERROR: {e}")
+                    # endregion""",
+        )
+
+        with open(path, "w") as f:
+            f.write(content)
+        print("Patched survey_responses.py successfully")
+    else:
+        print("Target not found in survey_responses.py")
+
+
+patch_file()

--- a/instrument-fix3.py
+++ b/instrument-fix3.py
@@ -1,0 +1,59 @@
+def patch_file():
+    path = "/Users/liozakirav/Documents/Projects/budget-survey/application/routes/survey_responses.py"
+    with open(path, "r") as f:
+        content = f.read()
+
+    target = """                    # region agent log
+                    import json
+                    with open("/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log", "a") as f:
+                        f.write(json.dumps({
+                            "sessionId": "363d07",
+                            "hypothesisId": "H1",
+                            "location": "survey_responses.py:get_user_responses",
+                            "message": "Sorted user_choices",
+                            "data": {
+                                "sort_by": sort_by,
+                                "reverse": reverse,
+                                "order": [(c["user_id"], c.get("total_response_time_seconds")) for c in user_choices[:10]]
+                            }
+                        }) + "\\n")
+                    # endregion"""
+
+    replacement = """                    # region agent log
+                    import json
+                    import os
+                    log_dir = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor"
+                    if not os.path.exists(log_dir):
+                        try:
+                            os.makedirs(log_dir, exist_ok=True)
+                        except Exception:
+                            pass
+                    
+                    log_path = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log"
+                    try:
+                        with open(log_path, "a") as f:
+                            f.write(json.dumps({
+                                "sessionId": "363d07",
+                                "hypothesisId": "H1",
+                                "location": "survey_responses.py:get_user_responses",
+                                "message": "Sorted user_choices",
+                                "data": {
+                                    "sort_by": sort_by,
+                                    "reverse": reverse,
+                                    "order": [(c["user_id"], c.get("total_response_time_seconds")) for c in user_choices[:10]]
+                                }
+                            }) + "\\n")
+                    except Exception as e:
+                        print(f"DEBUG LOG ERROR: {e}")
+                    # endregion"""
+
+    if target in content:
+        content = content.replace(target, replacement)
+        with open(path, "w") as f:
+            f.write(content)
+        print("Patched survey_responses.py successfully")
+    else:
+        print("Target not found in survey_responses.py")
+
+
+patch_file()

--- a/instrument-fix4.py
+++ b/instrument-fix4.py
@@ -1,0 +1,48 @@
+def patch_file():
+    path = "/Users/liozakirav/Documents/Projects/budget-survey/analysis/presentation/html_renderers.py"
+    with open(path, "r") as f:
+        content = f.read()
+
+    target = """        # region agent log
+        import json
+        import os
+        log_dir = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor"
+        if not os.path.exists(log_dir):
+            try:
+                os.makedirs(log_dir, exist_ok=True)
+            except Exception:
+                pass
+        
+        # In Docker, the path might be different, let's try a relative path or stdout fallback
+        log_path = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log"
+        try:
+            with open(log_path, "a") as f:
+                f.write(json.dumps({
+                    "sessionId": "363d07",
+                    "runId": "post-fix",
+                    "hypothesisId": "H1",
+                    "location": "html_renderers.py:generate_detailed_breakdown_table",
+                    "message": "Final sorted summaries",
+                    "data": {
+                        "sort_by": sort_by, 
+                        "sort_key": sort_key, 
+                        "reverse": reverse,
+                        "order": [(s["user_id"], s.get("choices", [{}])[0].get("total_response_time_seconds")) for s in sorted_summaries]
+                    }
+                }) + "\\n")
+        except Exception as e:
+            print(f"DEBUG LOG ERROR: {e}")
+        # endregion"""
+
+    replacement = ""
+
+    if target in content:
+        content = content.replace(target, replacement)
+        with open(path, "w") as f:
+            f.write(content)
+        print("Removed instrumentation from html_renderers.py")
+    else:
+        print("Instrumentation not found in html_renderers.py")
+
+
+patch_file()

--- a/instrument-fix5.py
+++ b/instrument-fix5.py
@@ -1,0 +1,45 @@
+def patch_file():
+    path = "/Users/liozakirav/Documents/Projects/budget-survey/application/routes/survey_responses.py"
+    with open(path, "r") as f:
+        content = f.read()
+
+    target = """                    # region agent log
+                    import json
+                    import os
+                    log_dir = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor"
+                    if not os.path.exists(log_dir):
+                        try:
+                            os.makedirs(log_dir, exist_ok=True)
+                        except Exception:
+                            pass
+                    
+                    log_path = "/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log"
+                    try:
+                        with open(log_path, "a") as f:
+                            f.write(json.dumps({
+                                "sessionId": "363d07",
+                                "hypothesisId": "H1",
+                                "location": "survey_responses.py:get_user_responses",
+                                "message": "Sorted user_choices",
+                                "data": {
+                                    "sort_by": sort_by,
+                                    "reverse": reverse,
+                                    "order": [(c["user_id"], c.get("total_response_time_seconds")) for c in user_choices[:10]]
+                                }
+                            }) + "\\n")
+                    except Exception as e:
+                        print(f"DEBUG LOG ERROR: {e}")
+                    # endregion"""
+
+    replacement = ""
+
+    if target in content:
+        content = content.replace(target, replacement)
+        with open(path, "w") as f:
+            f.write(content)
+        print("Removed instrumentation from survey_responses.py")
+    else:
+        print("Instrumentation not found in survey_responses.py")
+
+
+patch_file()

--- a/instrument.py
+++ b/instrument.py
@@ -1,0 +1,35 @@
+def patch_file():
+    path = "/Users/liozakirav/Documents/Projects/budget-survey/analysis/presentation/html_renderers.py"
+    with open(path, "r") as f:
+        content = f.read()
+
+    target = """        key_map = {"user_id": "user_id", "created_at": "response_created_at"}
+        sort_key = key_map.get(sort_by, "response_created_at")
+        reverse = (sort_order.lower() == "desc") if sort_by else True"""
+
+    replacement = """        key_map = {"user_id": "user_id", "created_at": "response_created_at"}
+        sort_key = key_map.get(sort_by, "response_created_at")
+        reverse = (sort_order.lower() == "desc") if sort_by else True
+        
+        # region agent log
+        import json
+        with open("/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log", "a") as f:
+            f.write(json.dumps({
+                "sessionId": "363d07",
+                "hypothesisId": "H1",
+                "location": "html_renderers.py:generate_detailed_breakdown_table",
+                "message": "Sorting params",
+                "data": {"sort_by": sort_by, "sort_order": sort_order, "sort_key": sort_key, "reverse": reverse}
+            }) + "\\n")
+        # endregion"""
+
+    if target in content:
+        content = content.replace(target, replacement)
+        with open(path, "w") as f:
+            f.write(content)
+        print("Patched successfully")
+    else:
+        print("Target not found")
+
+
+patch_file()

--- a/instrument2.py
+++ b/instrument2.py
@@ -1,0 +1,40 @@
+def patch_file():
+    path = "/Users/liozakirav/Documents/Projects/budget-survey/analysis/presentation/html_renderers.py"
+    with open(path, "r") as f:
+        content = f.read()
+
+    target = """        sorted_summaries = sorted(
+            survey_summaries, key=lambda x: x.get(sort_key, "") or "", reverse=reverse
+        )"""
+
+    replacement = """        sorted_summaries = sorted(
+            survey_summaries, key=lambda x: x.get(sort_key, "") or "", reverse=reverse
+        )
+        
+        # region agent log
+        import json
+        with open("/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log", "a") as f:
+            f.write(json.dumps({
+                "sessionId": "363d07",
+                "hypothesisId": "H1",
+                "location": "html_renderers.py:generate_detailed_breakdown_table",
+                "message": "Sorted summaries",
+                "data": {
+                    "sort_by": sort_by, 
+                    "sort_key": sort_key, 
+                    "reverse": reverse,
+                    "order": [(s["user_id"], str(s.get(sort_key, ""))) for s in sorted_summaries]
+                }
+            }) + "\\n")
+        # endregion"""
+
+    if target in content:
+        content = content.replace(target, replacement)
+        with open(path, "w") as f:
+            f.write(content)
+        print("Patched successfully")
+    else:
+        print("Target not found")
+
+
+patch_file()

--- a/instrument3.py
+++ b/instrument3.py
@@ -1,0 +1,45 @@
+def patch_file():
+    path = "/Users/liozakirav/Documents/Projects/budget-survey/application/routes/survey_responses.py"
+    with open(path, "r") as f:
+        content = f.read()
+
+    target = """                elif sort_by == "duration":
+                    # Handle None values by putting them at the end
+                    def get_duration(x):
+                        val = x.get("total_response_time_seconds")
+                        return float(val) if val is not None else (float('-inf') if reverse else float('inf'))
+                    user_choices.sort(key=get_duration, reverse=reverse)"""
+
+    replacement = """                elif sort_by == "duration":
+                    # Handle None values by putting them at the end
+                    def get_duration(x):
+                        val = x.get("total_response_time_seconds")
+                        return float(val) if val is not None else (float('-inf') if reverse else float('inf'))
+                    user_choices.sort(key=get_duration, reverse=reverse)
+                    
+                    # region agent log
+                    import json
+                    with open("/Users/liozakirav/Documents/Projects/budget-survey/.cursor/debug-363d07.log", "a") as f:
+                        f.write(json.dumps({
+                            "sessionId": "363d07",
+                            "hypothesisId": "H1",
+                            "location": "survey_responses.py:get_user_responses",
+                            "message": "Sorted user_choices",
+                            "data": {
+                                "sort_by": sort_by,
+                                "reverse": reverse,
+                                "order": [(c["user_id"], c.get("total_response_time_seconds")) for c in user_choices[:10]]
+                            }
+                        }) + "\\n")
+                    # endregion"""
+
+    if target in content:
+        content = content.replace(target, replacement)
+        with open(path, "w") as f:
+            f.write(content)
+        print("Patched successfully")
+    else:
+        print("Target not found")
+
+
+patch_file()

--- a/migrations/20260414_add_total_response_time.sql
+++ b/migrations/20260414_add_total_response_time.sql
@@ -1,0 +1,5 @@
+-- Migration: Add total_response_time_seconds to survey_responses table
+-- Description: Tracks the total cognitive load (time in seconds) a user spends on the survey page.
+
+ALTER TABLE `survey_responses`
+ADD COLUMN `total_response_time_seconds` FLOAT DEFAULT NULL COMMENT 'Total time spent on the survey page in seconds';

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -90,6 +90,7 @@ In chronological order:
 - `20251125_add_pair_generation_metadata.sql` - Adds generation_metadata JSON column to comparison_pairs for storing pair generation metadata
 - `20251204_add_pts_value_column.sql` - Adds pts_value column to survey_responses to record early awareness failures (PTS=7/10)
 - `20251204_add_survey_response_uniqueness.sql` - Adds unique constraint on (user_id, survey_id) to prevent duplicate survey responses
+- `20260414_add_total_response_time.sql` - Adds total_response_time_seconds column to survey_responses table to track total time spent on the survey page
 =======
 - `20251125_add_pair_generation_metadata.sql` - Adds generation_metadata JSON column to comparison_pairs table for storing pair generation metadata (e.g., relaxation level, epsilon)
 >>>>>>> 3a1a967 (feat: Add rank-based optimization metrics strategy with adaptive relaxation)


### PR DESCRIPTION
# Feat: Add Client-Side Response Time Tracking

## 📝 Summary
This PR implements a feature to track the total response time of a survey from the moment the page loads until the user submits the form. This helps researchers measure cognitive load and identify suspiciously fast responses.

## 🛠 Key Changes
- **Database**: Added a nullable `total_response_time_seconds` float column to the `survey_responses` table.
- **Frontend (JS)**: Implemented Vanilla JS in `application/static/js/survey.js` to measure time deltas using `performance.now()`. It captures the time on `DOMContentLoaded` and calculates the delta on `mouseenter`, `focus` on the submit button, and `submit` event, appending it to a hidden form input.
- **Backend (Python)**: Updated the `SurveySubmission` dataclass, `create_survey_response` query, and CSV export logic to handle the new optional float field.
- **UI (Individual Response)**: Added a "Response Time" badge to the `/surveys/{survey_id}/users/{user_id}/responses` endpoint, next to the "Ideal budget" badge.
- **UI (Survey Responses)**: 
  - Added an "Avg. Duration" badge to the top of the `/surveys/{survey_id}/responses` endpoint.
  - Renamed the existing "Response Time" column to "Submitted At".
  - Added a new sortable "Duration" column to the breakdown table.
  - Implemented outlier highlighting (red text, warning icon) for responses faster than a configurable threshold (default 60s).
- **Configuration**: Added `SUSPICIOUS_RESPONSE_TIME_THRESHOLD_SECONDS` to `config.py`.

## 🚀 Impact
Researchers can now analyze the time taken by each user to complete a survey, view the average response time for a survey, and easily spot suspiciously fast "speedrun" responses.

## ⚠️ Action Required
You must run the database migration to add the new column:

```bash
python migrations/run_migration.py migrations/20260414_add_total_response_time.sql
```