### PR TITLE
Feat: Add Cosine Similarity Utility Model and Rank Comparison Surveys

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ Note: '>' represents observed choice, which may include cases of user indifferen
   - **L1 (Sum)**: Total absolute disagreement.
   - **Leontief (Ratio)**: Minimal satisfaction ratio (fairness).
   - **L2 (RSS)**: Euclidean distance (penalizes extreme outliers).
+  - **Cosine Similarity**: Alignment of relative budget priorities.
   - **Anti-Leontief**: Penalizes over-funding (waste aversion).
   - **Kullback-Leibler (KL)**: Information theoretic divergence (asymmetric penalty for losses).
 

--- a/application/services/algorithms/utility_models.py
+++ b/application/services/algorithms/utility_models.py
@@ -80,6 +80,38 @@ class L2UtilityModel(UtilityModel):
         return -float(dist)
 
 
+class CosineSimilarityUtilityModel(UtilityModel):
+    """
+    Implements cosine similarity as a scoring utility model.
+
+    Cosine similarity compares the direction of two budget vectors rather than
+    their absolute distance. In this context, it measures whether a candidate
+    budget preserves the user's relative priority pattern.
+
+    Higher Score = Better Match (1.0 means identical direction).
+    """
+
+    @property
+    def name(self) -> str:
+        return "cosine_similarity"
+
+    @property
+    def utility_type(self) -> str:
+        return "similarity"
+
+    def calculate(
+        self, user_vec: Tuple[float, ...], candidate_vec: Tuple[float, ...]
+    ) -> float:
+        user_arr = np.array(user_vec, dtype=float)
+        comp_arr = np.array(candidate_vec, dtype=float)
+
+        denominator = np.linalg.norm(user_arr) * np.linalg.norm(comp_arr)
+        if denominator == 0:
+            return 0.0
+
+        return float(np.dot(user_arr, comp_arr) / denominator)
+
+
 class LeontiefUtilityModel(UtilityModel):
     """
     Implements Leontief ratio as a scoring utility model.

--- a/application/services/pair_generation/__init__.py
+++ b/application/services/pair_generation/__init__.py
@@ -11,6 +11,10 @@ from .multi_dimensional_single_peaked import MultiDimensionalSinglePeakedStrateg
 from .optimization_metrics_vector import OptimizationMetricsStrategy
 from .preference_ranking_survey import PreferenceRankingSurveyStrategy
 from .rank_strategies import (
+    CosineSimilarityVsKLRankStrategy,
+    CosineSimilarityVsL1RankStrategy,
+    CosineSimilarityVsL2RankStrategy,
+    CosineSimilarityVsLeontiefRankStrategy,
     KLVsAntiLeontiefRankStrategy,
     KLVsL1RankStrategy,
     KLVsL2RankStrategy,
@@ -33,6 +37,10 @@ StrategyRegistry.register(OptimizationMetricsStrategy)
 StrategyRegistry.register(L1VsLeontiefRankStrategy)
 StrategyRegistry.register(L1VsL2RankStrategy)
 StrategyRegistry.register(L2VsLeontiefRankStrategy)
+StrategyRegistry.register(CosineSimilarityVsL1RankStrategy)
+StrategyRegistry.register(CosineSimilarityVsL2RankStrategy)
+StrategyRegistry.register(CosineSimilarityVsLeontiefRankStrategy)
+StrategyRegistry.register(CosineSimilarityVsKLRankStrategy)
 StrategyRegistry.register(LeontiefVsAntiLeontiefRankStrategy)
 StrategyRegistry.register(LeontiefVsKLRankStrategy)
 StrategyRegistry.register(KLVsAntiLeontiefRankStrategy)
@@ -59,6 +67,10 @@ __all__ = [
     "L1VsLeontiefRankStrategy",
     "L1VsL2RankStrategy",
     "L2VsLeontiefRankStrategy",
+    "CosineSimilarityVsL1RankStrategy",
+    "CosineSimilarityVsL2RankStrategy",
+    "CosineSimilarityVsLeontiefRankStrategy",
+    "CosineSimilarityVsKLRankStrategy",
     "LeontiefVsAntiLeontiefRankStrategy",
     "LeontiefVsKLRankStrategy",
     "KLVsAntiLeontiefRankStrategy",

--- a/application/services/pair_generation/rank_strategies.py
+++ b/application/services/pair_generation/rank_strategies.py
@@ -7,6 +7,7 @@ import logging
 
 from application.services.algorithms.utility_models import (
     AntiLeontiefUtilityModel,
+    CosineSimilarityUtilityModel,
     KLUtilityModel,
     L1UtilityModel,
     L2UtilityModel,
@@ -71,6 +72,66 @@ class L2VsLeontiefRankStrategy(GenericRankStrategy):
         super().__init__(
             utility_model_a_class=L2UtilityModel,
             utility_model_b_class=LeontiefUtilityModel,
+            grid_step=grid_step,
+            min_component=10,
+            normalization_method="ordinal",
+        )
+
+
+class CosineSimilarityVsL1RankStrategy(GenericRankStrategy):
+    """
+    Strategy comparing cosine similarity against L1 distance (Sum).
+    """
+
+    def __init__(self, grid_step: int = None):
+        super().__init__(
+            utility_model_a_class=CosineSimilarityUtilityModel,
+            utility_model_b_class=L1UtilityModel,
+            grid_step=grid_step,
+            min_component=0,
+            normalization_method="ordinal",
+        )
+
+
+class CosineSimilarityVsL2RankStrategy(GenericRankStrategy):
+    """
+    Strategy comparing cosine similarity against L2 distance (Root Sum Squared).
+    """
+
+    def __init__(self, grid_step: int = None):
+        super().__init__(
+            utility_model_a_class=CosineSimilarityUtilityModel,
+            utility_model_b_class=L2UtilityModel,
+            grid_step=grid_step,
+            min_component=0,
+            normalization_method="ordinal",
+        )
+
+
+class CosineSimilarityVsLeontiefRankStrategy(GenericRankStrategy):
+    """
+    Strategy comparing cosine similarity against Leontief ratio (Ratio).
+    """
+
+    def __init__(self, grid_step: int = None):
+        super().__init__(
+            utility_model_a_class=CosineSimilarityUtilityModel,
+            utility_model_b_class=LeontiefUtilityModel,
+            grid_step=grid_step,
+            min_component=10,
+            normalization_method="ordinal",
+        )
+
+
+class CosineSimilarityVsKLRankStrategy(GenericRankStrategy):
+    """
+    Strategy comparing cosine similarity against KL divergence.
+    """
+
+    def __init__(self, grid_step: int = None):
+        super().__init__(
+            utility_model_a_class=CosineSimilarityUtilityModel,
+            utility_model_b_class=KLUtilityModel,
             grid_step=grid_step,
             min_component=10,
             normalization_method="ordinal",

--- a/application/translations.py
+++ b/application/translations.py
@@ -778,6 +778,10 @@ TRANSLATIONS: Dict[str, Dict[str, Dict[str, str]]] = {
         "sum": {"he": "סכום", "en": "Sum"},
         "l1": {"he": "L1", "en": "L1"},
         "l2": {"he": "L2", "en": "L2"},
+        "cosine_similarity": {
+            "he": "Cosine Similarity",
+            "en": "Cosine Similarity",
+        },
         "leontief": {"he": "Leontief", "en": "Leontief"},
         "anti_leontief": {"he": "AntiLeontief", "en": "AntiLeontief"},
         "kl": {"he": "KL", "en": "KL"},

--- a/migrations/20260512_add_cosine_similarity_surveys.sql
+++ b/migrations/20260512_add_cosine_similarity_surveys.sql
@@ -1,60 +1,189 @@
--- Migration: Add cosine similarity rank-comparison surveys
+-- Migration: Add cosine similarity rank-comparison surveys for all stories
 -- Date: 2026-05-12
 
 START TRANSACTION;
 
-SET @cosine_story_code := COALESCE(
-    (SELECT code FROM stories WHERE code = 'government_budget' LIMIT 1),
-    (SELECT code FROM stories WHERE code = 'budget_2024' LIMIT 1),
-    (SELECT code FROM stories ORDER BY code LIMIT 1)
-);
+-- ==========================================
+-- 1. PRODUCTION STORIES
+-- ==========================================
+
+-- --- government_budget ---
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'government_budget', TRUE, '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison');
 
 INSERT INTO surveys (story_code, active, pair_generation_config)
-SELECT
-    @cosine_story_code,
-    TRUE,
-    '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
-WHERE @cosine_story_code IS NOT NULL
-AND NOT EXISTS (
-    SELECT 1
-    FROM surveys
-    WHERE JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison'
-);
+SELECT 'government_budget', TRUE, '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison');
 
 INSERT INTO surveys (story_code, active, pair_generation_config)
-SELECT
-    @cosine_story_code,
-    TRUE,
-    '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
-WHERE @cosine_story_code IS NOT NULL
-AND NOT EXISTS (
-    SELECT 1
-    FROM surveys
-    WHERE JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison'
-);
+SELECT 'government_budget', TRUE, '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison');
 
 INSERT INTO surveys (story_code, active, pair_generation_config)
-SELECT
-    @cosine_story_code,
-    TRUE,
-    '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
-WHERE @cosine_story_code IS NOT NULL
-AND NOT EXISTS (
-    SELECT 1
-    FROM surveys
-    WHERE JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison'
-);
+SELECT 'government_budget', TRUE, '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison');
+
+
+-- --- government_budget_4_subjects ---
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'government_budget_4_subjects', TRUE, '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget_4_subjects')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget_4_subjects' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison');
 
 INSERT INTO surveys (story_code, active, pair_generation_config)
-SELECT
-    @cosine_story_code,
-    TRUE,
-    '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
-WHERE @cosine_story_code IS NOT NULL
-AND NOT EXISTS (
-    SELECT 1
-    FROM surveys
-    WHERE JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison'
-);
+SELECT 'government_budget_4_subjects', TRUE, '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget_4_subjects')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget_4_subjects' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'government_budget_4_subjects', TRUE, '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget_4_subjects')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget_4_subjects' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'government_budget_4_subjects', TRUE, '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget_4_subjects')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget_4_subjects' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison');
+
+
+-- --- government_budget_5_subjects ---
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'government_budget_5_subjects', TRUE, '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget_5_subjects')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget_5_subjects' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'government_budget_5_subjects', TRUE, '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget_5_subjects')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget_5_subjects' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'government_budget_5_subjects', TRUE, '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget_5_subjects')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget_5_subjects' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'government_budget_5_subjects', TRUE, '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'government_budget_5_subjects')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'government_budget_5_subjects' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison');
+
+
+-- --- municipal_budget ---
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'municipal_budget', TRUE, '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'municipal_budget')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'municipal_budget' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'municipal_budget', TRUE, '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'municipal_budget')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'municipal_budget' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'municipal_budget', TRUE, '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'municipal_budget')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'municipal_budget' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'municipal_budget', TRUE, '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'municipal_budget')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'municipal_budget' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison');
+
+
+-- ==========================================
+-- 2. DEVELOPMENT STORIES
+-- ==========================================
+
+-- --- budget_2024 ---
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2024', TRUE, '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2024')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2024' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2024', TRUE, '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2024')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2024' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2024', TRUE, '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2024')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2024' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2024', TRUE, '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2024')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2024' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison');
+
+
+-- --- budget_2025 ---
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2025', TRUE, '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2025')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2025' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2025', TRUE, '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2025')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2025' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2025', TRUE, '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2025')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2025' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2025', TRUE, '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2025')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2025' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison');
+
+
+-- --- budget_2026_4D ---
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2026_4D', TRUE, '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2026_4D')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2026_4D' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2026_4D', TRUE, '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2026_4D')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2026_4D' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2026_4D', TRUE, '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2026_4D')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2026_4D' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2026_4D', TRUE, '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2026_4D')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2026_4D' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison');
+
+
+-- --- budget_2027_5D ---
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2027_5D', TRUE, '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2027_5D')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2027_5D' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2027_5D', TRUE, '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2027_5D')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2027_5D' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2027_5D', TRUE, '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2027_5D')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2027_5D' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison');
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT 'budget_2027_5D', TRUE, '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE EXISTS (SELECT 1 FROM stories WHERE code = 'budget_2027_5D')
+AND NOT EXISTS (SELECT 1 FROM surveys WHERE story_code = 'budget_2027_5D' AND JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison');
 
 COMMIT;

--- a/migrations/20260512_add_cosine_similarity_surveys.sql
+++ b/migrations/20260512_add_cosine_similarity_surveys.sql
@@ -1,0 +1,60 @@
+-- Migration: Add cosine similarity rank-comparison surveys
+-- Date: 2026-05-12
+
+START TRANSACTION;
+
+SET @cosine_story_code := COALESCE(
+    (SELECT code FROM stories WHERE code = 'government_budget' LIMIT 1),
+    (SELECT code FROM stories WHERE code = 'budget_2024' LIMIT 1),
+    (SELECT code FROM stories ORDER BY code LIMIT 1)
+);
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT
+    @cosine_story_code,
+    TRUE,
+    '{"strategy": "cosine_similarity_vs_l1_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE @cosine_story_code IS NOT NULL
+AND NOT EXISTS (
+    SELECT 1
+    FROM surveys
+    WHERE JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l1_rank_comparison'
+);
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT
+    @cosine_story_code,
+    TRUE,
+    '{"strategy": "cosine_similarity_vs_l2_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE @cosine_story_code IS NOT NULL
+AND NOT EXISTS (
+    SELECT 1
+    FROM surveys
+    WHERE JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_l2_rank_comparison'
+);
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT
+    @cosine_story_code,
+    TRUE,
+    '{"strategy": "cosine_similarity_vs_leontief_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE @cosine_story_code IS NOT NULL
+AND NOT EXISTS (
+    SELECT 1
+    FROM surveys
+    WHERE JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_leontief_rank_comparison'
+);
+
+INSERT INTO surveys (story_code, active, pair_generation_config)
+SELECT
+    @cosine_story_code,
+    TRUE,
+    '{"strategy": "cosine_similarity_vs_kl_rank_comparison", "params": {"num_pairs": 10}}'
+WHERE @cosine_story_code IS NOT NULL
+AND NOT EXISTS (
+    SELECT 1
+    FROM surveys
+    WHERE JSON_UNQUOTE(JSON_EXTRACT(pair_generation_config, '$.strategy')) = 'cosine_similarity_vs_kl_rank_comparison'
+);
+
+COMMIT;

--- a/tests/services/algorithms/test_utility_models.py
+++ b/tests/services/algorithms/test_utility_models.py
@@ -3,6 +3,7 @@ import pytest
 
 from application.services.algorithms.utility_models import (
     AntiLeontiefUtilityModel,
+    CosineSimilarityUtilityModel,
     KLUtilityModel,
     L1UtilityModel,
     L2UtilityModel,
@@ -43,6 +44,30 @@ def test_l2_utility_model_calculation():
     )
 
 
+def test_cosine_similarity_utility_model_calculation():
+    """
+    Test cosine similarity utility model.
+    Formula: U = dot(p, q) / (||p|| * ||q||).
+    """
+    utility_model = CosineSimilarityUtilityModel()
+
+    assert utility_model.name == "cosine_similarity"
+    assert utility_model.utility_type == "similarity"
+
+    # Identical direction is the best possible similarity score.
+    assert pytest.approx(utility_model.calculate((50, 30, 20), (50, 30, 20))) == 1.0
+
+    # Orthogonal non-negative budget vectors have no directional overlap.
+    assert utility_model.calculate((100, 0), (0, 100)) == 0.0
+
+    # 45-degree case: dot=50, ||p||=100, ||q||=sqrt(50^2 + 50^2).
+    expected = 1 / np.sqrt(2)
+    assert pytest.approx(utility_model.calculate((100, 0), (50, 50))) == expected
+
+    # Degenerate zero vectors are not valid budgets, but the model remains safe.
+    assert utility_model.calculate((0, 0), (50, 50)) == 0.0
+
+
 def test_leontief_utility_model_calculation():
     utility_model = LeontiefUtilityModel()
     user_vec = (10, 90)
@@ -75,6 +100,7 @@ def test_perfect_match():
     vec = (33.3, 33.3, 33.4)
     assert L1UtilityModel().calculate(vec, vec) == 0.0
     assert L2UtilityModel().calculate(vec, vec) == 0.0
+    assert pytest.approx(CosineSimilarityUtilityModel().calculate(vec, vec)) == 1.0
     assert LeontiefUtilityModel().calculate(vec, vec) == 1.0
 
 

--- a/tests/services/pair_generation/test_rank_strategies.py
+++ b/tests/services/pair_generation/test_rank_strategies.py
@@ -3,6 +3,10 @@
 import pytest
 
 from application.services.pair_generation.rank_strategies import (
+    CosineSimilarityVsKLRankStrategy,
+    CosineSimilarityVsL1RankStrategy,
+    CosineSimilarityVsL2RankStrategy,
+    CosineSimilarityVsLeontiefRankStrategy,
     KLVsAntiLeontiefRankStrategy,
     KLVsL1RankStrategy,
     KLVsL2RankStrategy,
@@ -27,6 +31,26 @@ def l1_l2_strategy():
 @pytest.fixture
 def l2_leo_strategy():
     return L2VsLeontiefRankStrategy()
+
+
+@pytest.fixture
+def cosine_l1_strategy():
+    return CosineSimilarityVsL1RankStrategy()
+
+
+@pytest.fixture
+def cosine_l2_strategy():
+    return CosineSimilarityVsL2RankStrategy()
+
+
+@pytest.fixture
+def cosine_leontief_strategy():
+    return CosineSimilarityVsLeontiefRankStrategy()
+
+
+@pytest.fixture
+def cosine_kl_strategy():
+    return CosineSimilarityVsKLRankStrategy()
 
 
 @pytest.fixture
@@ -159,6 +183,60 @@ class TestL2VsLeontiefRankStrategy:
             descriptions = [k for k in pair.keys() if k != "__metadata__"]
             assert any("l2:" in d for d in descriptions)
             assert any("leontief:" in d for d in descriptions)
+
+
+@pytest.mark.parametrize(
+    ("strategy_fixture", "strategy_name", "other_model", "expected_min_component"),
+    [
+        (
+            "cosine_l1_strategy",
+            "cosine_similarity_vs_l1_rank_comparison",
+            "l1",
+            0,
+        ),
+        (
+            "cosine_l2_strategy",
+            "cosine_similarity_vs_l2_rank_comparison",
+            "l2",
+            0,
+        ),
+        (
+            "cosine_leontief_strategy",
+            "cosine_similarity_vs_leontief_rank_comparison",
+            "leontief",
+            10,
+        ),
+        (
+            "cosine_kl_strategy",
+            "cosine_similarity_vs_kl_rank_comparison",
+            "kl",
+            10,
+        ),
+    ],
+)
+def test_cosine_similarity_rank_strategies(
+    request, strategy_fixture, strategy_name, other_model, expected_min_component
+):
+    """Verify cosine similarity rank strategies use the generic rank pipeline."""
+    strategy = request.getfixturevalue(strategy_fixture)
+
+    assert strategy.get_strategy_name() == strategy_name
+    assert strategy.min_component == expected_min_component
+    assert strategy.get_option_labels() == (
+        "cosine_similarity (Rank)",
+        f"{other_model} (Rank)",
+    )
+
+    columns = strategy.get_table_columns()
+    assert "cosine_similarity" in columns
+    assert other_model in columns
+
+    pairs = strategy.generate_pairs((50, 30, 20), n=2, vector_size=3)
+    assert len(pairs) == 2
+    for pair in pairs:
+        descriptions = [k for k in pair.keys() if k != "__metadata__"]
+        assert any("cosine_similarity:" in d for d in descriptions)
+        assert any(f"{other_model}:" in d for d in descriptions)
 
 
 class TestLeontiefVsAntiLeontiefRankStrategy:


### PR DESCRIPTION
# Feat: Add Cosine Similarity Utility Model and Rank Comparison Surveys

## 📝 Summary
This PR implements the **Cosine Similarity** utility model and integrates it into the rank-based pair generation system. It introduces four new comparison surveys comparing Cosine Similarity against L1, L2, Leontief, and KL utility models, allowing researchers to evaluate how users trade off directional alignment (relative priorities) against distance-based, ratio-based, and divergence-based models.

## 🛠 Key Changes
- **Algorithms**: Implemented `CosineSimilarityUtilityModel` in `application/services/algorithms/utility_models.py` which calculates the directional similarity of budget vectors using NumPy. It includes safety checks for zero-vector edge cases.
- **Pair Generation**: Introduced four new concrete ranking-based pair generation strategies in `application/services/pair_generation/rank_strategies.py`:
  - `CosineSimilarityVsL1RankStrategy` (using `min_component=0`)
  - `CosineSimilarityVsL2RankStrategy` (using `min_component=0`)
  - `CosineSimilarityVsLeontiefRankStrategy` (using `min_component=10`)
  - `CosineSimilarityVsKLRankStrategy` (using `min_component=10`)
- **Strategy Registration**: Registered and exported the new strategies in `application/services/pair_generation/__init__.py`.
- **Database Migration**: Added an idempotent SQL migration script `migrations/20260512_add_cosine_similarity_surveys.sql` that inserts the four new cosine similarity surveys for all production stories.
- **Translations**: Added Hebrew and English display labels for `"cosine_similarity"` in `application/translations.py`.
- **Documentation**: Documented Cosine Similarity in the "Utility Models Supported" section of the `README.md`.
- **Tests**: Added comprehensive unit tests for mathematical accuracy in `tests/services/algorithms/test_utility_models.py` and parameterized integration tests for strategy verification in `tests/services/pair_generation/test_rank_strategies.py`.

## 🚀 Impact
Researchers can now run surveys comparing Cosine Similarity with other utility models to see if users prefer budget allocations that preserve their relative priority patterns (directional alignment) over absolute distance or ratio-based satisfaction.

## ⚠️ Action Required
You must run the database migration to add the new surveys:

```bash
python migrations/run_migration.py migrations/20260512_add_cosine_similarity_surveys.sql
```